### PR TITLE
Content assist for elements with cardinality "many"

### DIFF
--- a/packages/simple-schema/lib/content-assist/element-name.js
+++ b/packages/simple-schema/lib/content-assist/element-name.js
@@ -12,9 +12,9 @@ const { difference, map, filter } = require("lodash");
  */
 function elementNameCompletion(elementNode, xssElement, prefix = "") {
   const allPossibleSuggestions = map(xssElement.elements, _ => _.name);
-  const notSingularElemNames = filter(
-    xssElement.elements,
-    _ => _.cardinality === "many"
+  const notSingularElemNames = map(
+    filter(xssElement.elements, _ => _.cardinality === "many"),
+    _ => _.name
   );
   const existingElemNames = map(elementNode.subElements, _ => _.name);
   const existingSingular = difference(existingElemNames, notSingularElemNames);

--- a/packages/simple-schema/lib/content-assist/element-name.js
+++ b/packages/simple-schema/lib/content-assist/element-name.js
@@ -12,10 +12,11 @@ const { difference, map, filter } = require("lodash");
  */
 function elementNameCompletion(elementNode, xssElement, prefix = "") {
   const allPossibleSuggestions = map(xssElement.elements, _ => _.name);
-  const notSingularElemNames = map(
-    filter(xssElement.elements, _ => _.cardinality === "many"),
-    _ => _.name
+  const notSingularElem = filter(
+    xssElement.elements,
+    _ => _.cardinality === "many"
   );
+  const notSingularElemNames = map(notSingularElem, _ => _.name);
   const existingElemNames = map(elementNode.subElements, _ => _.name);
   const existingSingular = difference(existingElemNames, notSingularElemNames);
   const possibleSuggestionsWithoutExistingSingular = difference(

--- a/packages/simple-schema/test/content-assist/element-name-spec.js
+++ b/packages/simple-schema/test/content-assist/element-name-spec.js
@@ -188,6 +188,62 @@ describe("The XML Simple Schema", () => {
           }
         ]);
       });
+      it("allows multiple sub-elements with `multiple` cardinality", () => {
+        const xmlText = `<people>
+                    <person>
+                      <age>66</age>
+                    </person>
+                    <⇶
+                  </people>`;
+
+        const schema = {
+          required: true,
+          cardinality: "single",
+          name: "people",
+          attributes: {},
+
+          elements: {
+            person: {
+              name: "person",
+              required: false,
+              cardinality: "many",
+              attributes: {},
+              elements: {
+                name: {
+                  cardinality: "single",
+                  required: false,
+                  name: "name",
+                  attributes: {},
+                  elements: {}
+                },
+                age: {
+                  cardinality: "single",
+                  required: false,
+                  name: "age",
+                  attributes: {},
+                  elements: {}
+                },
+                address: {
+                  cardinality: "many",
+                  required: false,
+                  name: "address",
+                  attributes: {},
+                  elements: {}
+                }
+              }
+            }
+          }
+        };
+
+        const suggestions = suggestionsBySchema(xmlText, schema);
+        expect(suggestions).to.deep.include.members([
+          {
+            label: "person",
+            text: "person"
+          }
+        ]);
+        expect(suggestions).to.have.lengthOf(1);
+      });
     });
   });
 });


### PR DESCRIPTION
Sub elements with cardinality "many" were not correctly handled by simple schemas element name content assist provider - it was treated as element with cardinality "single".

Added a test case and fixed the issue.