### PR TITLE
Default namespace is missing in AST

### DIFF
--- a/packages/ast/lib/build-ast.js
+++ b/packages/ast/lib/build-ast.js
@@ -259,7 +259,7 @@ function updateNamespaces(element, prevNamespaces = []) {
     (result, attrib) => {
       /* istanbul ignore else - Defensive Coding, not actually possible branch */
       if (attrib.key !== invalidSyntax) {
-        const nsMatch = /^xmlns:([^:]+)$/.exec(attrib.key);
+        const nsMatch = /^xmlns(?::([^:]+))?$/.exec(attrib.key);
         if (nsMatch !== null) {
           const prefix = nsMatch[1];
           if (attrib.value) {

--- a/packages/ast/test/snapshots/valid/namespaces/input.xml
+++ b/packages/ast/test/snapshots/valid/namespaces/input.xml
@@ -1,6 +1,7 @@
 
-<f:table xmlns:f="https://blah.com/furniture">
+<f:table xmlns:f="https://blah.com/furniture" xmlns="https://blah.com/default">
     <f:name>Some Chair</f:name>
     <f:width>50</f:width>
     <f:length>67</f:length>
+    <description>Awsome Chair</description>
 </f:table>

--- a/packages/ast/test/snapshots/valid/namespaces/output.js
+++ b/packages/ast/test/snapshots/valid/namespaces/output.js
@@ -3,7 +3,10 @@ module.exports = {
     type: "XMLDocument",
     rootElement: {
       type: "XMLElement",
-      namespaces: [{ prefix: "f", uri: "https://blah.com/furniture" }],
+      namespaces: [
+        { prefix: "f", uri: "https://blah.com/furniture" },
+        { prefix: undefined, uri: "https://blah.com/default" }
+      ],
       name: "table",
       attributes: [
         {
@@ -19,103 +22,162 @@ module.exports = {
               endOffset: 45
             }
           }
+        },
+        {
+          type: "XMLAttribute",
+          position: { startOffset: 47, endOffset: 78 },
+          key: "xmlns",
+          value: "https://blah.com/default",
+          syntax: {
+            key: { image: "xmlns", startOffset: 47, endOffset: 51 },
+            value: {
+              image: '"https://blah.com/default"',
+              startOffset: 53,
+              endOffset: 78
+            }
+          }
         }
       ],
       subElements: [
         {
           type: "XMLElement",
-          namespaces: [{ prefix: "f", uri: "https://blah.com/furniture" }],
+          namespaces: [
+            { prefix: "f", uri: "https://blah.com/furniture" },
+            { prefix: undefined, uri: "https://blah.com/default" }
+          ],
           name: "name",
           attributes: [],
           subElements: [],
           textContents: [
             {
               type: "XMLTextContent",
-              position: { startOffset: 60, endOffset: 69 },
+              position: { startOffset: 93, endOffset: 102 },
               text: "Some Chair"
             }
           ],
-          position: { startOffset: 52, endOffset: 78 },
+          position: { startOffset: 85, endOffset: 111 },
           syntax: {
-            openName: { image: "f:name", startOffset: 53, endOffset: 58 },
-            openBody: { startOffset: 52, endOffset: 59 },
-            closeName: { image: "f:name", startOffset: 72, endOffset: 77 }
+            openName: { image: "f:name", startOffset: 86, endOffset: 91 },
+            openBody: { startOffset: 85, endOffset: 92 },
+            closeName: { image: "f:name", startOffset: 105, endOffset: 110 }
           },
           ns: "f"
         },
         {
           type: "XMLElement",
-          namespaces: [{ prefix: "f", uri: "https://blah.com/furniture" }],
+          namespaces: [
+            { prefix: "f", uri: "https://blah.com/furniture" },
+            { prefix: undefined, uri: "https://blah.com/default" }
+          ],
           name: "width",
           attributes: [],
           subElements: [],
           textContents: [
             {
               type: "XMLTextContent",
-              position: { startOffset: 93, endOffset: 94 },
+              position: { startOffset: 126, endOffset: 127 },
               text: "50"
             }
           ],
-          position: { startOffset: 84, endOffset: 104 },
+          position: { startOffset: 117, endOffset: 137 },
           syntax: {
-            openName: { image: "f:width", startOffset: 85, endOffset: 91 },
-            openBody: { startOffset: 84, endOffset: 92 },
-            closeName: { image: "f:width", startOffset: 97, endOffset: 103 }
+            openName: { image: "f:width", startOffset: 118, endOffset: 124 },
+            openBody: { startOffset: 117, endOffset: 125 },
+            closeName: { image: "f:width", startOffset: 130, endOffset: 136 }
           },
           ns: "f"
         },
         {
           type: "XMLElement",
-          namespaces: [{ prefix: "f", uri: "https://blah.com/furniture" }],
+          namespaces: [
+            { prefix: "f", uri: "https://blah.com/furniture" },
+            { prefix: undefined, uri: "https://blah.com/default" }
+          ],
           name: "length",
           attributes: [],
           subElements: [],
           textContents: [
             {
               type: "XMLTextContent",
-              position: { startOffset: 120, endOffset: 121 },
+              position: { startOffset: 153, endOffset: 154 },
               text: "67"
             }
           ],
-          position: { startOffset: 110, endOffset: 132 },
+          position: { startOffset: 143, endOffset: 165 },
           syntax: {
-            openName: { image: "f:length", startOffset: 111, endOffset: 118 },
-            openBody: { startOffset: 110, endOffset: 119 },
-            closeName: { image: "f:length", startOffset: 124, endOffset: 131 }
+            openName: { image: "f:length", startOffset: 144, endOffset: 151 },
+            openBody: { startOffset: 143, endOffset: 152 },
+            closeName: { image: "f:length", startOffset: 157, endOffset: 164 }
           },
           ns: "f"
+        },
+        {
+          type: "XMLElement",
+          namespaces: [
+            { prefix: "f", uri: "https://blah.com/furniture" },
+            { prefix: undefined, uri: "https://blah.com/default" }
+          ],
+          name: "description",
+          attributes: [],
+          subElements: [],
+          textContents: [
+            {
+              type: "XMLTextContent",
+              position: { startOffset: 184, endOffset: 195 },
+              text: "Awsome Chair"
+            }
+          ],
+          position: { startOffset: 171, endOffset: 209 },
+          syntax: {
+            openName: {
+              image: "description",
+              startOffset: 172,
+              endOffset: 182
+            },
+            openBody: { startOffset: 171, endOffset: 183 },
+            closeName: {
+              image: "description",
+              startOffset: 198,
+              endOffset: 208
+            }
+          }
         }
       ],
       textContents: [
         {
           type: "XMLTextContent",
-          position: { startOffset: 47, endOffset: 51 },
+          position: { startOffset: 80, endOffset: 84 },
           text: "\n    "
         },
         {
           type: "XMLTextContent",
-          position: { startOffset: 79, endOffset: 83 },
+          position: { startOffset: 112, endOffset: 116 },
           text: "\n    "
         },
         {
           type: "XMLTextContent",
-          position: { startOffset: 105, endOffset: 109 },
+          position: { startOffset: 138, endOffset: 142 },
           text: "\n    "
         },
         {
           type: "XMLTextContent",
-          position: { startOffset: 133, endOffset: 133 },
+          position: { startOffset: 166, endOffset: 170 },
+          text: "\n    "
+        },
+        {
+          type: "XMLTextContent",
+          position: { startOffset: 210, endOffset: 210 },
           text: "\n"
         }
       ],
-      position: { startOffset: 1, endOffset: 143 },
+      position: { startOffset: 1, endOffset: 220 },
       syntax: {
         openName: { image: "f:table", startOffset: 2, endOffset: 8 },
-        openBody: { startOffset: 1, endOffset: 46 },
-        closeName: { image: "f:table", startOffset: 136, endOffset: 142 }
+        openBody: { startOffset: 1, endOffset: 79 },
+        closeName: { image: "f:table", startOffset: 213, endOffset: 219 }
       },
       ns: "f"
     },
-    position: { startOffset: 0, endOffset: 144 }
+    position: { startOffset: 0, endOffset: 221 }
   }
 };


### PR DESCRIPTION
Added default namespace to the`XMLElement` node in AST.

For XML:
```
<Element xmlns="https://default.com" />
```

`XMLElement` namespaces should contain a namespace with URI `https://default.com` and no prefix.