### PR TITLE
fix: simple schema with xml namespaces

### DIFF
--- a/packages/content-assist/api.d.ts
+++ b/packages/content-assist/api.d.ts
@@ -15,6 +15,8 @@ interface CompletionSuggestion {
   text: string;
   label?: string;
   docs?: string;
+  commitCharacter?: string;
+  isNamespace?: boolean;
   /**
    * A measure of how certain we are about this suggestion's relevance.
    * This value could be used to:

--- a/packages/simple-schema/api.d.ts
+++ b/packages/simple-schema/api.d.ts
@@ -26,10 +26,10 @@ declare type XSSElement = {
   namespace?: string;
 
   attributesType?: "open" | "closed";
-  attributes?: Record<string, XSSAttribute>;
+  attributes: Record<string, XSSAttribute>;
 
   elementsType?: "open" | "closed";
-  elements?: Record<string, XSSElement>;
+  elements: Record<string, XSSElement>;
   // TODO: textValue definition (for simple pure text only?)
 };
 

--- a/packages/simple-schema/lib/content-assist/attribute-name.js
+++ b/packages/simple-schema/lib/content-assist/attribute-name.js
@@ -13,15 +13,12 @@ function attributeNameCompletion(elementNode, xssElement, prefix = "") {
     possibleSuggestions,
     existingAttribNames
   );
-  const possibleNewSuggestionsMatchingPrefix = filter(
-    possibleNewSuggestions,
-    _ => _.startsWith(prefix)
-  );
 
-  const suggestions = map(possibleNewSuggestionsMatchingPrefix, _ => {
+  const suggestions = map(possibleNewSuggestions, _ => {
     return {
-      text: _.substring(prefix.length),
-      label: _
+      text: _,
+      label: _,
+      commitCharacter: "="
     };
   });
 

--- a/packages/simple-schema/lib/content-assist/element-name.js
+++ b/packages/simple-schema/lib/content-assist/element-name.js
@@ -1,6 +1,7 @@
 const { difference, map, filter, find } = require("lodash");
 
-const NAMESPACE_PATTERN = /^(?:([^:]*):)?(.*)$/;
+// https://www.w3.org/TR/2009/REC-xml-names-20091208/#NT-PrefixedName
+const NAMESPACE_PATTERN = /^(?:([^:]*):)?([^:]*)$/;
 /**
  *
  * Note that the Element (XML/XSS) are of the parent node of the element

--- a/packages/simple-schema/lib/get-content-assist.js
+++ b/packages/simple-schema/lib/get-content-assist.js
@@ -23,7 +23,7 @@ function getSchemaSuggestionsProviders(schema) {
 function buildAttributeNameProvider(schema) {
   return ({ element, prefix }) => {
     const xssElementDef = findElementXssDef(element, schema);
-    if (xssElementDef) {
+    if (xssElementDef !== undefined) {
       return attributeNameCompletion(element, xssElementDef, prefix);
     } else {
       return [];
@@ -39,7 +39,7 @@ function buildElementNameProvider(schema) {
     // Note we are finding the definition for the element's parent
     // Because the information on possible sibling elements exists there...
     const xssElementDef = findElementXssDef(element.parent, schema);
-    if (xssElementDef) {
+    if (xssElementDef !== undefined) {
       return elementNameCompletion(element.parent, xssElementDef, prefix);
     } else {
       return [];

--- a/packages/simple-schema/lib/get-content-assist.js
+++ b/packages/simple-schema/lib/get-content-assist.js
@@ -23,7 +23,11 @@ function getSchemaSuggestionsProviders(schema) {
 function buildAttributeNameProvider(schema) {
   return ({ element, prefix }) => {
     const xssElementDef = findElementXssDef(element, schema);
-    return attributeNameCompletion(element, xssElementDef, prefix);
+    if (xssElementDef) {
+      return attributeNameCompletion(element, xssElementDef, prefix);
+    } else {
+      return [];
+    }
   };
 }
 
@@ -35,7 +39,11 @@ function buildElementNameProvider(schema) {
     // Note we are finding the definition for the element's parent
     // Because the information on possible sibling elements exists there...
     const xssElementDef = findElementXssDef(element.parent, schema);
-    return elementNameCompletion(element.parent, xssElementDef, prefix);
+    if (xssElementDef) {
+      return elementNameCompletion(element.parent, xssElementDef, prefix);
+    } else {
+      return [];
+    }
   };
 }
 

--- a/packages/simple-schema/lib/validators/unknown-attributes.js
+++ b/packages/simple-schema/lib/validators/unknown-attributes.js
@@ -23,7 +23,7 @@ function validateUnknownAttributes(elem, schema) {
     if (attrib.key !== null) {
       if (
         includes(allowedAttribNames, attrib.key) === false &&
-        !NAMESPACE_ATTRRIBUTE_PATTERN.test(attrib.key)
+        NAMESPACE_ATTRRIBUTE_PATTERN.test(attrib.key) === false
       ) {
         issues.push({
           msg: `Unknown Attribute: <${

--- a/packages/simple-schema/lib/validators/unknown-attributes.js
+++ b/packages/simple-schema/lib/validators/unknown-attributes.js
@@ -1,6 +1,7 @@
 const { map, includes, forEach } = require("lodash");
 const { tokenToOffsetPosition } = require("./utils");
 
+const NAMESPACE_ATTRRIBUTE_PATTERN = /^xmlns(:[^=]*)?$/;
 /**
  * @param {XMLElement} elem
  * @param {XSSElement} schema
@@ -20,7 +21,10 @@ function validateUnknownAttributes(elem, schema) {
      * reproduce this branch with current error recovery heuristics
      */
     if (attrib.key !== null) {
-      if (includes(allowedAttribNames, attrib.key) === false) {
+      if (
+        includes(allowedAttribNames, attrib.key) === false &&
+        !NAMESPACE_ATTRRIBUTE_PATTERN.test(attrib.key)
+      ) {
         issues.push({
           msg: `Unknown Attribute: <${
             attrib.key

--- a/packages/simple-schema/test/content-assist/atrribute-name-spec.js
+++ b/packages/simple-schema/test/content-assist/atrribute-name-spec.js
@@ -40,21 +40,24 @@ describe("The XML Simple Schema", () => {
         };
 
         const suggestions = suggestionsBySchema(xmlText, schema);
-        expect(suggestions).to.have.lengthOf(3);
         expect(suggestions).to.deep.include.members([
           {
             label: "name",
-            text: "name"
+            text: "name",
+            commitCharacter: "="
           },
           {
             label: "age",
-            text: "age"
+            text: "age",
+            commitCharacter: "="
           },
           {
             label: "address",
-            text: "address"
+            text: "address",
+            commitCharacter: "="
           }
         ]);
+        expect(suggestions).to.have.lengthOf(3);
       });
 
       it("provides suggestion: with prefix", () => {
@@ -93,17 +96,42 @@ describe("The XML Simple Schema", () => {
         };
 
         const suggestions = suggestionsBySchema(xmlText, schema);
-        expect(suggestions).to.have.lengthOf(2);
         expect(suggestions).to.deep.include.members([
           {
+            label: "name",
+            text: "name",
+            commitCharacter: "="
+          },
+          {
             label: "age",
-            text: "ge"
+            text: "age",
+            commitCharacter: "="
           },
           {
             label: "address",
-            text: "ddress"
+            text: "address",
+            commitCharacter: "="
           }
         ]);
+        expect(suggestions).to.have.lengthOf(3);
+      });
+      it("does not crash wehen xss element does not exist", () => {
+        const xmlText = `<people>
+                    <person a⇶></person>
+                  </people>`;
+
+        const schema = {
+          required: true,
+          cardinality: "single",
+          name: "people",
+          attributes: {},
+
+          elements: {}
+        };
+
+        const suggestions = suggestionsBySchema(xmlText, schema);
+        expect(suggestions).to.deep.include.members([]);
+        expect(suggestions).to.have.lengthOf(0);
       });
 
       it("filters suggestions by existing attributes", () => {
@@ -142,17 +170,19 @@ describe("The XML Simple Schema", () => {
         };
 
         const suggestions = suggestionsBySchema(xmlText, schema);
-        expect(suggestions).to.have.lengthOf(2);
         expect(suggestions).to.deep.include.members([
           {
             label: "name",
-            text: "name"
+            text: "name",
+            commitCharacter: "="
           },
           {
             label: "address",
-            text: "address"
+            text: "address",
+            commitCharacter: "="
           }
         ]);
+        expect(suggestions).to.have.lengthOf(2);
       });
     });
   });

--- a/packages/simple-schema/test/content-assist/atrribute-value-spec.js
+++ b/packages/simple-schema/test/content-assist/atrribute-value-spec.js
@@ -158,6 +158,24 @@ describe("The XML Simple Schema", () => {
         const suggestions = suggestionsBySchema(xmlText, schema);
         expect(suggestions).to.have.lengthOf(0);
       });
+
+      it("Does not crash if there is no XSS value definition", () => {
+        const xmlText = `<people>
+                    <person age="⇶"></person>
+                  </people>`;
+
+        const schema = {
+          required: true,
+          cardinality: "single",
+          name: "people",
+          attributes: {},
+
+          elements: {}
+        };
+
+        const suggestions = suggestionsBySchema(xmlText, schema);
+        expect(suggestions).to.have.lengthOf(0);
+      });
     });
   });
 });

--- a/packages/simple-schema/test/content-assist/element-name-spec.js
+++ b/packages/simple-schema/test/content-assist/element-name-spec.js
@@ -320,7 +320,6 @@ describe("The XML Simple Schema", () => {
       };
 
       const suggestions = suggestionsBySchema(xmlText, schema);
-      console.log(suggestions);
       expect(suggestions).to.deep.include.members([
         {
           text: "abc",
@@ -342,6 +341,123 @@ describe("The XML Simple Schema", () => {
         }
       ]);
       expect(suggestions).to.have.lengthOf(4);
+    });
+    it("with namespace prefix", () => {
+      const xmlText = `<abc:people xmlns:abc="http://namespace.com/1">
+                    <person xmlns="http://namespace.com/2">
+                      <abc:⇶
+                    </person>
+                  </abc:people>`;
+
+      const schema = {
+        required: true,
+        cardinality: "single",
+        name: "people",
+        namespace: "http://namespace.com/1",
+        attributes: {},
+        elements: {
+          person: {
+            name: "person",
+            namespace: "http://namespace.com/2",
+            required: false,
+            cardinality: "many",
+            attributes: {},
+            elements: {
+              name: {
+                cardinality: "single",
+                required: false,
+                name: "name",
+                namespace: "http://namespace.com/1",
+                attributes: {},
+                elements: {}
+              },
+              age: {
+                cardinality: "single",
+                required: false,
+                name: "age",
+                namespace: "http://namespace.com/1",
+                attributes: {},
+                elements: {}
+              },
+              address: {
+                cardinality: "many",
+                required: false,
+                name: "address",
+                namespace: "http://namespace.com/2",
+                attributes: {},
+                elements: {}
+              }
+            }
+          }
+        }
+      };
+
+      const suggestions = suggestionsBySchema(xmlText, schema);
+      expect(suggestions).to.deep.include.members([
+        {
+          label: "name",
+          text: "name"
+        },
+        {
+          label: "age",
+          text: "age"
+        }
+      ]);
+      expect(suggestions).to.have.lengthOf(2);
+    });
+    it("should not crash with invalid prefix", () => {
+      const xmlText = `<abc:people xmlns:abc="http://namespace.com/1">
+                    <person xmlns="http://namespace.com/2">
+                      <:::⇶
+                    </person>
+                  </abc:people>`;
+
+      const schema = {
+        required: true,
+        cardinality: "single",
+        name: "people",
+        namespace: "http://namespace.com/1",
+        attributes: {},
+        elements: {
+          person: {
+            name: "person",
+            namespace: "http://namespace.com/2",
+            required: false,
+            cardinality: "many",
+            attributes: {},
+            elements: {
+              name: {
+                cardinality: "single",
+                required: false,
+                name: "name",
+                namespace: "http://namespace.com/2",
+                attributes: {},
+                elements: {}
+              },
+              age: {
+                cardinality: "single",
+                required: false,
+                name: "age",
+                namespace: "http://namespace.com/2",
+                attributes: {},
+                elements: {}
+              },
+              address: {
+                cardinality: "many",
+                required: false,
+                name: "address",
+                namespace: "http://namespace.com/2",
+                attributes: {},
+                elements: {}
+              }
+            }
+          }
+        }
+      };
+
+      const suggestions = suggestionsBySchema(xmlText, schema);
+      expect(suggestions).to.deep.include.members([]);
+      expect(suggestions).to.have.lengthOf(0);
     });
   });
 });

--- a/packages/simple-schema/test/content-assist/element-name-spec.js
+++ b/packages/simple-schema/test/content-assist/element-name-spec.js
@@ -51,7 +51,6 @@ describe("The XML Simple Schema", () => {
         };
 
         const suggestions = suggestionsBySchema(xmlText, schema);
-        expect(suggestions).to.have.lengthOf(3);
         expect(suggestions).to.deep.include.members([
           {
             label: "name",
@@ -66,6 +65,7 @@ describe("The XML Simple Schema", () => {
             text: "address"
           }
         ]);
+        expect(suggestions).to.have.lengthOf(3);
       });
 
       it("provides suggestion: with prefix", () => {
@@ -115,17 +115,21 @@ describe("The XML Simple Schema", () => {
         };
 
         const suggestions = suggestionsBySchema(xmlText, schema);
-        expect(suggestions).to.have.lengthOf(2);
         expect(suggestions).to.deep.include.members([
           {
+            label: "name",
+            text: "name"
+          },
+          {
             label: "age",
-            text: "ge"
+            text: "age"
           },
           {
             label: "address",
-            text: "ddress"
+            text: "address"
           }
         ]);
+        expect(suggestions).to.have.lengthOf(3);
       });
 
       it("filters pre-existing sub-elements with `single` cardinality", () => {
@@ -176,7 +180,6 @@ describe("The XML Simple Schema", () => {
         };
 
         const suggestions = suggestionsBySchema(xmlText, schema);
-        expect(suggestions).to.have.lengthOf(2);
         expect(suggestions).to.deep.include.members([
           {
             label: "name",
@@ -187,6 +190,7 @@ describe("The XML Simple Schema", () => {
             text: "address"
           }
         ]);
+        expect(suggestions).to.have.lengthOf(2);
       });
       it("allows multiple sub-elements with `multiple` cardinality", () => {
         const xmlText = `<people>
@@ -244,6 +248,100 @@ describe("The XML Simple Schema", () => {
         ]);
         expect(suggestions).to.have.lengthOf(1);
       });
+    });
+    it("does not crash if there is no xss element", () => {
+      const xmlText = `<people>
+                    <person>
+                      <⇶
+                    </person>
+                  </people>`;
+
+      const schema = {
+        required: true,
+        cardinality: "single",
+        name: "people",
+        attributes: {},
+
+        elements: {}
+      };
+
+      const suggestions = suggestionsBySchema(xmlText, schema);
+      expect(suggestions).to.deep.include.members([]);
+      expect(suggestions).to.have.lengthOf(0);
+    });
+    it("nested elements with namespces", () => {
+      const xmlText = `<abc:people xmlns:abc="http://namespace.com/1">
+                    <person xmlns="http://namespace.com/2">
+                      <⇶
+                    </person>
+                  </abc:people>`;
+
+      const schema = {
+        required: true,
+        cardinality: "single",
+        name: "people",
+        namespace: "http://namespace.com/1",
+        attributes: {},
+        elements: {
+          person: {
+            name: "person",
+            namespace: "http://namespace.com/2",
+            required: false,
+            cardinality: "many",
+            attributes: {},
+            elements: {
+              name: {
+                cardinality: "single",
+                required: false,
+                name: "name",
+                namespace: "http://namespace.com/2",
+                attributes: {},
+                elements: {}
+              },
+              age: {
+                cardinality: "single",
+                required: false,
+                name: "age",
+                namespace: "http://namespace.com/2",
+                attributes: {},
+                elements: {}
+              },
+              address: {
+                cardinality: "many",
+                required: false,
+                name: "address",
+                namespace: "http://namespace.com/2",
+                attributes: {},
+                elements: {}
+              }
+            }
+          }
+        }
+      };
+
+      const suggestions = suggestionsBySchema(xmlText, schema);
+      console.log(suggestions);
+      expect(suggestions).to.deep.include.members([
+        {
+          text: "abc",
+          label: "abc",
+          isNamespace: true,
+          commitCharacter: ":"
+        },
+        {
+          label: "name",
+          text: "name"
+        },
+        {
+          label: "age",
+          text: "age"
+        },
+        {
+          label: "address",
+          text: "address"
+        }
+      ]);
+      expect(suggestions).to.have.lengthOf(4);
     });
   });
 });

--- a/packages/simple-schema/test/validators/element-unknown-attributes-spec.js
+++ b/packages/simple-schema/test/validators/element-unknown-attributes-spec.js
@@ -119,6 +119,77 @@ describe("The XML Simple Schema", () => {
         const issues = validateBySchema(xmlText, schema);
         expect(issues).to.be.empty;
       });
+
+      it("Default namespace attribute is always known", () => {
+        const xmlText = `<people xmlns="http://people.com">
+                 <person name="Donald" age="1"></person>
+             </people>`;
+
+        const schema = {
+          required: true,
+          name: "people",
+          cardinality: "single",
+          attributesType: "closed",
+          attributes: {
+            description: {
+              key: "description",
+              required: false
+            }
+          },
+
+          elements: {
+            person: {
+              name: "person",
+              required: false,
+              cardinality: "many",
+              attributes: {
+                age: {
+                  required: true,
+                  key: "age"
+                }
+              },
+              elements: {}
+            }
+          }
+        };
+        const issues = validateBySchema(xmlText, schema);
+        expect(issues).to.have.lengthOf(0);
+      });
+      it("Namespace attribute with prefix is always known", () => {
+        const xmlText = `<people xmlns:people="http://people.com">
+                 <person name="Donald" age="1"></person>
+             </people>`;
+
+        const schema = {
+          required: true,
+          name: "people",
+          cardinality: "single",
+          attributesType: "closed",
+          attributes: {
+            description: {
+              key: "description",
+              required: false
+            }
+          },
+
+          elements: {
+            person: {
+              name: "person",
+              required: false,
+              cardinality: "many",
+              attributes: {
+                age: {
+                  required: true,
+                  key: "age"
+                }
+              },
+              elements: {}
+            }
+          }
+        };
+        const issues = validateBySchema(xmlText, schema);
+        expect(issues).to.have.lengthOf(0);
+      });
     });
   });
 });


### PR DESCRIPTION
Simple schema did not correctly handle XML documents with namespaces. This pull request fixes the following issues:

1. Providing false validation errors for namespace attributes (https://www.w3.org/TR/xml-names/)
2. Namespaces not used in element name suggestion items
3. Crashing if there is no schema for the given element


Other changes:
1. Add commit character property to the suggestion item API. (character that can be used to select the item from the code completion list and also insert it after the completion text)
2. Removed suggestion item filtering by prefix, because the provider should give all the possible values and any filtering required based on user input should be handled by the consumer. 