### PR TITLE
fix(content-assist): crash with invalid xml

### DIFF
--- a/packages/content-assist/lib/content-assist.js
+++ b/packages/content-assist/lib/content-assist.js
@@ -266,7 +266,7 @@ function handleNewAttributeKeyScenario(ctx, astNode, tokenVector, visitor) {
      */
   } else if (hasTerminatedAttribRange === false) {
     handleNewAttributeKeyForPartialElement(
-      ctx.Name[0],
+      ctx.Name ? ctx.Name[0] : ctx.OPEN[0],
       tokenVector,
       visitor,
       astNode

--- a/packages/content-assist/test/scenarios-spec.js
+++ b/packages/content-assist/test/scenarios-spec.js
@@ -60,6 +60,23 @@ describe("The XML Content Assist Capabilities", () => {
         expect(providerCalled).to.be.true;
       });
 
+      it("Before invalid element", () => {
+        const sample = `<person gender="female">` + `⇶` + `<\n</person>`;
+
+        let providerCalled = false;
+        getSampleSuggestions(sample, {
+          elementContent: [
+            ({ element, prefix, textContent }) => {
+              expect(prefix).to.be.undefined;
+              expect(textContent).to.be.undefined;
+              expect(element.name).to.eql("person");
+              providerCalled = true;
+            }
+          ]
+        });
+        expect(providerCalled).to.be.true;
+      });
+
       it("before comment", () => {
         const sample =
           `<person gender="female">\n` +


### PR DESCRIPTION
### Issue

Content assist crashes if there is opening tag without closing bracket.

e.g 
```
<sample>|<<sample>
```

### Changes

For attribute range recovery use OPEN token in case Name token does not exist.