### PR TITLE
feat(content-assist): context resolution API

### DIFF
--- a/packages/content-assist/api.d.ts
+++ b/packages/content-assist/api.d.ts
@@ -6,68 +6,32 @@ import {
   XMLDocument
 } from "@xml-tools/ast";
 
-declare function computeCompletionContext(params: {
+declare function getSuggestions<T>(options: {
   cst: CstNode;
   ast: XMLDocument;
   offset: number;
   tokenVector: IToken[];
-}): {
-  providerType: ProviderType;
-  providerArgs: {
-    prefix?: string;
-    element: XMLElement;
-    attribute?: XMLAttribute;
-  };
+  providers: SuggestionProviders<T>;
+}): T[];
+
+declare type SuggestionProviders<T> = {
+  elementContent?: ElementContentCompletion<T>[];
+  elementName?: ElementNameCompletion<T>[];
+  attributeName?: AttributeNameCompletion<T>[];
+  attributeValue?: AttributeValueCompletion<T>[];
 };
 
-type ProviderType =
-  | "elementContent"
-  | "elementName"
-  | "attributeName"
-  | "attributeValue";
+declare type ProviderOptions =
+  | ElementContentCompletionOptions
+  | ElementNameCompletionOptions
+  | AttributeNameCompletionOptions
+  | AttributeValueCompletionOptions;
 
-declare function getSuggestions(options: {
-  text: string;
-  offset: number;
-  providers: {
-    elementContent?: ElementContentCompletion[];
-    elementName?: ElementNameCompletion[];
-    attributeName?: AttributeNameCompletion[];
-    attributeValue?: AttributeValueCompletion[];
-  };
-}): CompletionSuggestion[];
+declare type SuggestionProvider<O extends ProviderOptions, T> = (
+  options: O
+) => T[];
 
-interface CompletionSuggestion {
-  text: string;
-  label?: string;
-  docs?: string;
-  commitCharacter?: string;
-  isNamespace?: boolean;
-  /**
-   * A measure of how certain we are about this suggestion's relevance.
-   * This value could be used to:
-   * - Filter out less relevant suggestions when there are too many possible suggestions.
-   * - Sort the suggestions by relevance.
-   */
-  confidence?: number;
-}
-
-/**
- *  Suggestions provider for element's contents.
- *  This is triggered when content assist is requested:
- *  1. **inside** an element's contents.
- *  2. And **outside** any of the element's sub-parts
- *
- *  For example: ('⇶' marks the content assist position):
- *  - <note>
- *     <to>bobi</to>
- *     ⇶
- *     <!-- I am a comment! -->
- *    </note>
- *
- *  - <name>⇶</name>
- */
-declare type ElementContentCompletion = (options: {
+declare type ElementContentCompletionOptions = {
   /**
    * Element ASTNode for which the name content assist was requested.
    * This ASTNode may be used to:
@@ -88,8 +52,38 @@ declare type ElementContentCompletion = (options: {
    * Note that this property may be undefined if no prefix was provided.
    */
   textContent: XMLTextContent | undefined;
-}) => CompletionSuggestion[];
+};
+/**
+ *  Suggestions provider for element's contents.
+ *  This is triggered when content assist is requested:
+ *  1. **inside** an element's contents.
+ *  2. And **outside** any of the element's sub-parts
+ *
+ *  For example: ('⇶' marks the content assist position):
+ *  - <note>
+ *     <to>bobi</to>
+ *     ⇶
+ *     <!-- I am a comment! -->
+ *    </note>
+ *
+ *  - <name>⇶</name>
+ */
+declare type ElementContentCompletion<T> = SuggestionProvider<
+  ElementContentCompletionOptions,
+  T
+>;
 
+declare type ElementNameCompletionOptions = {
+  /**
+   * Element ASTNode for which the name content assist was requested
+   */
+  element: XMLElement;
+  /**
+   * The pre-existing part of the name at the content assist request offset.
+   * This would normally be used to filter out suggestions that do not match the prefix.
+   */
+  prefix: string | undefined;
+};
 /**
  *  Suggestions provider for element names.
  *  This is triggered when content assist is requested:
@@ -101,26 +95,12 @@ declare type ElementContentCompletion = (options: {
  *  - <pers⇶
  *  - <⇶
  */
-declare type ElementNameCompletion = (options: {
-  /**
-   * Element ASTNode for which the name content assist was requested
-   */
-  element: XMLElement;
-  /**
-   * The pre-existing part of the name at the content assist request offset.
-   * This would normally be used to filter out suggestions that do not match the prefix.
-   */
-  prefix: string | undefined;
-}) => CompletionSuggestion[];
+declare type ElementNameCompletion<T> = SuggestionProvider<
+  ElementNameCompletionOptions,
+  T
+>;
 
-/**
- *  Suggestions provider for attribute names.
- *  This is triggered when content assist is requested **inside** an element opening name block
- *  in a position where an attribute is valid e.g ('⇶' marks the content assist position):
- *  - <person age='45' nam⇶  >
- *  - <person age='45' ⇶  >
- */
-declare type AttributeNameCompletion = (options: {
+declare type AttributeNameCompletionOptions = {
   /**
    * Element ASTNode in which content assist was requested
    * This ASTNode may be used to:
@@ -139,17 +119,21 @@ declare type AttributeNameCompletion = (options: {
    * This would normally be used to filter out suggestions that do not match the prefix.
    */
   prefix: string | undefined;
-}) => CompletionSuggestion[];
+};
 
 /**
- *  Suggestions provider for attribute values.
- *  This is triggered when content assist is requested **inside** the quotes
- *  d.g: ('⇶' marks the content assist position):
- *  - <meeting day='wednes⇶' >
- *  - <meeting day='⇶' >
- *  - ...
+ *  Suggestions provider for attribute names.
+ *  This is triggered when content assist is requested **inside** an element opening name block
+ *  in a position where an attribute is valid e.g ('⇶' marks the content assist position):
+ *  - <person age='45' nam⇶  >
+ *  - <person age='45' ⇶  >
  */
-declare type AttributeValueCompletion = (options: {
+declare type AttributeNameCompletion<T> = SuggestionProvider<
+  AttributeNameCompletionOptions,
+  T
+>;
+
+declare type AttributeValueCompletionOptions = {
   /**
    * Element ASTNode in which content assist was requested
    */
@@ -169,4 +153,17 @@ declare type AttributeValueCompletion = (options: {
    * Note that the prefix does not include any quotes.
    */
   prefix: string | undefined;
-}) => CompletionSuggestion[];
+};
+
+/**
+ *  Suggestions provider for attribute values.
+ *  This is triggered when content assist is requested **inside** the quotes
+ *  d.g: ('⇶' marks the content assist position):
+ *  - <meeting day='wednes⇶' >
+ *  - <meeting day='⇶' >
+ *  - ...
+ */
+declare type AttributeValueCompletion<T> = SuggestionProvider<
+  AttributeValueCompletionOptions,
+  T
+>;

--- a/packages/content-assist/api.d.ts
+++ b/packages/content-assist/api.d.ts
@@ -1,4 +1,30 @@
-import { XMLAttribute, XMLElement, XMLTextContent } from "@xml-tools/ast";
+import { CstNode } from "chevrotain";
+import {
+  XMLAttribute,
+  XMLElement,
+  XMLTextContent,
+  XMLDocument
+} from "@xml-tools/ast";
+
+declare function computeCompletionContext(params: {
+  cst: CstNode;
+  ast: XMLDocument;
+  offset: number;
+  tokenVector: IToken[];
+}): {
+  providerType: ProviderType;
+  providerArgs: {
+    prefix?: string;
+    element: XMLElement;
+    attribute?: XMLAttribute;
+  };
+};
+
+type ProviderType =
+  | "elementContent"
+  | "elementName"
+  | "attributeName"
+  | "attributeValue";
 
 declare function getSuggestions(options: {
   text: string;

--- a/packages/content-assist/api.d.ts
+++ b/packages/content-assist/api.d.ts
@@ -1,4 +1,4 @@
-import { CstNode } from "chevrotain";
+import { CstNode, IToken } from "chevrotain";
 import {
   XMLAttribute,
   XMLElement,

--- a/packages/content-assist/lib/api.js
+++ b/packages/content-assist/lib/api.js
@@ -36,5 +36,6 @@ function getSuggestions(options) {
 }
 
 module.exports = {
-  getSuggestions: getSuggestions
+  getSuggestions: getSuggestions,
+  computeCompletionContext: computeCompletionContext
 };

--- a/packages/content-assist/lib/api.js
+++ b/packages/content-assist/lib/api.js
@@ -1,5 +1,3 @@
-const { parse } = require("@xml-tools/parser");
-const { buildAst, tokenVector } = require("@xml-tools/ast");
 const { defaultsDeep, flatMap } = require("lodash");
 
 const { computeCompletionContext } = require("./content-assist");
@@ -13,13 +11,11 @@ function getSuggestions(options) {
       attributeValue: []
     }
   });
-  const { cst, tokenVector } = parse(actualOptions.text);
-  const ast = buildAst(cst, tokenVector);
 
   const { providerType, providerArgs } = computeCompletionContext({
-    cst: cst,
-    tokenVector: tokenVector,
-    ast: ast,
+    cst: actualOptions.cst,
+    tokenVector: actualOptions.tokenVector,
+    ast: actualOptions.ast,
     offset: actualOptions.offset
   });
 
@@ -36,6 +32,5 @@ function getSuggestions(options) {
 }
 
 module.exports = {
-  getSuggestions: getSuggestions,
-  computeCompletionContext: computeCompletionContext
+  getSuggestions: getSuggestions
 };

--- a/packages/content-assist/test/scenarios-spec.js
+++ b/packages/content-assist/test/scenarios-spec.js
@@ -1,3 +1,5 @@
+const { parse } = require("@xml-tools/parser");
+const { buildAst } = require("@xml-tools/ast");
 const { expect } = require("chai");
 const { getSuggestions } = require("../");
 
@@ -499,8 +501,13 @@ describe("The XML Content Assist Capabilities", () => {
 function getSampleSuggestions(sample, providers) {
   const realSample = sample.replace("⇶", "");
   const offset = sample.indexOf("⇶");
+  const { cst, tokenVector } = parse(realSample);
+  const ast = buildAst(cst, tokenVector);
+
   return getSuggestions({
-    text: realSample,
+    cst,
+    ast,
+    tokenVector,
     offset: offset,
     providers: providers
   });

--- a/packages/simple-schema/api.d.ts
+++ b/packages/simple-schema/api.d.ts
@@ -51,12 +51,29 @@ declare function getSchemaValidators(
   element: ElementValidator;
 };
 
+interface CompletionSuggestion {
+  text: string;
+  label?: string;
+  docs?: string;
+  commitCharacter?: string;
+  isNamespace?: boolean;
+  /**
+   * A measure of how certain we are about this suggestion's relevance.
+   * This value could be used to:
+   * - Filter out less relevant suggestions when there are too many possible suggestions.
+   * - Sort the suggestions by relevance.
+   */
+  confidence?: number;
+}
+
 declare function getSchemaSuggestionsProviders(
   schema: SimpleSchema
 ): {
   // TBD in the future...
   // schemaElementContentCompletion: ElementContentCompletion;
-  schemaElementNameCompletion: ElementNameCompletion;
-  schemaAttributeNameCompletion: AttributeNameCompletion;
-  schemaAttributeValueCompletion: AttributeValueCompletion;
+  schemaElementNameCompletion: ElementNameCompletion<CompletionSuggestion>;
+  schemaAttributeNameCompletion: AttributeNameCompletion<CompletionSuggestion>;
+  schemaAttributeValueCompletion: AttributeValueCompletion<
+    CompletionSuggestion
+  >;
 };

--- a/packages/simple-schema/test/content-assist/utils.js
+++ b/packages/simple-schema/test/content-assist/utils.js
@@ -1,3 +1,5 @@
+const { parse } = require("@xml-tools/parser");
+const { buildAst } = require("@xml-tools/ast");
 const { getSuggestions } = require("@xml-tools/content-assist");
 const { getSchemaSuggestionsProviders } = require("../../");
 
@@ -11,8 +13,12 @@ function suggestionsBySchema(xmlText, schema) {
   const schemaSuggestionsProviders = getSchemaSuggestionsProviders(schema);
   const realXmlText = xmlText.replace("⇶", "");
   const offset = xmlText.indexOf("⇶");
+  const { cst, tokenVector } = parse(realXmlText);
+  const ast = buildAst(cst, tokenVector);
   const suggestions = getSuggestions({
-    text: realXmlText,
+    cst,
+    tokenVector,
+    ast,
     offset: offset,
     providers: {
       attributeValue: [


### PR DESCRIPTION
### Issue

When implementing [language server protocol](https://microsoft.github.io/language-server-protocol/) document changes and completion requests are coming in separately. On the document change parse the document, so later on when completion items are requested we already have CST and AST available for the document, so we could already pass that directly to the context resolution algorithm, however it only accepts text as a string.

### Changes

Add `computeCompletionContext` to the API. This allows reusing CST and AST if it is already available and avoid parsing the whole document on each completion request.