### PR TITLE
fix(parser): allow CData nodes to be multi-line

### DIFF
--- a/packages/parser/lib/lexer.js
+++ b/packages/parser/lib/lexer.js
@@ -50,7 +50,11 @@ const Comment = createToken({
   line_breaks: true
 });
 
-const CData = createToken({ name: "CData", pattern: /<!\[CDATA\[.*?]]>/ });
+const CData = createToken({
+  name: "CData",
+  pattern: /<!\[CDATA\[(.|\r?\n)*?]]>/,
+  line_breaks: true
+});
 
 const DocType = createToken({
   name: "DocType",


### PR DESCRIPTION
CData nodes can be multi-line, and need to allow newline characters between the start and end tags