### PR TITLE
feat(ast): element Namespaces are now represented as Records in a Map

### DIFF
--- a/packages/ast/api.d.ts
+++ b/packages/ast/api.d.ts
@@ -44,11 +44,18 @@ declare interface XMLProlog {
   readonly position: SourcePosition;
 }
 
+// A Prefix cannot include a colon ":" so the below string will never conflict
+// with a valid namespace prefix.
+declare type DefaultNS = "::DEFAULT";
+declare const DefaultNS: DefaultNS;
+declare type Prefix = string | DefaultNS;
+declare type Uri = string;
+
 declare interface XMLElement {
   readonly type: "XMLElement";
   readonly parent: XMLElement | XMLDocument;
 
-  readonly namespaces: { prefix?: string; uri: string }[];
+  readonly namespaces: Record<Prefix, Uri>;
 
   // namespace prefix used by this XML Element.
   // - Note that this is an optional syntax.

--- a/packages/ast/api.d.ts
+++ b/packages/ast/api.d.ts
@@ -47,7 +47,7 @@ declare interface XMLProlog {
 // A Prefix cannot include a colon ":" so the below string will never conflict
 // with a valid namespace prefix.
 declare type DefaultNS = "::DEFAULT";
-declare const DefaultNS: DefaultNS;
+declare const DEFAULT_NS: DefaultNS;
 declare type Prefix = string | DefaultNS;
 declare type Uri = string;
 

--- a/packages/ast/lib/api.js
+++ b/packages/ast/lib/api.js
@@ -1,7 +1,9 @@
 const { buildAst } = require("./build-ast");
 const { accept } = require("./visit-ast");
+const { DEFAULT_NS } = require("./constants");
 
 module.exports = {
   buildAst: buildAst,
-  accept: accept
+  accept: accept,
+  DEFAULT_NS: DEFAULT_NS
 };

--- a/packages/ast/lib/constants.js
+++ b/packages/ast/lib/constants.js
@@ -1,0 +1,3 @@
+module.exports = {
+  DEFAULT_NS: "::DEFAULT"
+};

--- a/packages/ast/test/snapshots/invalid/attributes-no-value-last/output.js
+++ b/packages/ast/test/snapshots/invalid/attributes-no-value-last/output.js
@@ -3,7 +3,7 @@ module.exports = {
     type: "XMLDocument",
     rootElement: {
       type: "XMLElement",
-      namespaces: [],
+      namespaces: {},
       name: "note",
       attributes: [
         {

--- a/packages/ast/test/snapshots/invalid/attributes-no-value-middle/output.js
+++ b/packages/ast/test/snapshots/invalid/attributes-no-value-middle/output.js
@@ -3,7 +3,7 @@ module.exports = {
     type: "XMLDocument",
     rootElement: {
       type: "XMLElement",
-      namespaces: [],
+      namespaces: {},
       name: "note",
       attributes: [
         {

--- a/packages/ast/test/snapshots/invalid/attributes-no-value-no-eql-last/output.js
+++ b/packages/ast/test/snapshots/invalid/attributes-no-value-no-eql-last/output.js
@@ -3,7 +3,7 @@ module.exports = {
     type: "XMLDocument",
     rootElement: {
       type: "XMLElement",
-      namespaces: [],
+      namespaces: {},
       name: "note",
       attributes: [
         {

--- a/packages/ast/test/snapshots/invalid/attributes-no-value-no-eql-middle/output.js
+++ b/packages/ast/test/snapshots/invalid/attributes-no-value-no-eql-middle/output.js
@@ -3,7 +3,7 @@ module.exports = {
     type: "XMLDocument",
     rootElement: {
       type: "XMLElement",
-      namespaces: [],
+      namespaces: {},
       name: "note",
       attributes: [
         {

--- a/packages/ast/test/snapshots/invalid/attributes-no-value-not-closed-nested/output.js
+++ b/packages/ast/test/snapshots/invalid/attributes-no-value-not-closed-nested/output.js
@@ -3,13 +3,13 @@ module.exports = {
     type: "XMLDocument",
     rootElement: {
       type: "XMLElement",
-      namespaces: [],
+      namespaces: {},
       name: "top",
       attributes: [],
       subElements: [
         {
           type: "XMLElement",
-          namespaces: [],
+          namespaces: {},
           name: "nested",
           attributes: [
             {
@@ -42,7 +42,7 @@ module.exports = {
         },
         {
           type: "XMLElement",
-          namespaces: [],
+          namespaces: {},
           name: "nest2",
           attributes: [],
           subElements: [],
@@ -64,7 +64,7 @@ module.exports = {
         },
         {
           type: "XMLElement",
-          namespaces: [],
+          namespaces: {},
           name: "nested3",
           attributes: [
             {

--- a/packages/ast/test/snapshots/invalid/attributes-no-value-not-closed/output.js
+++ b/packages/ast/test/snapshots/invalid/attributes-no-value-not-closed/output.js
@@ -3,7 +3,7 @@ module.exports = {
     type: "XMLDocument",
     rootElement: {
       type: "XMLElement",
-      namespaces: [],
+      namespaces: {},
       name: "note",
       attributes: [
         {

--- a/packages/ast/test/snapshots/invalid/bad-namespace/output.js
+++ b/packages/ast/test/snapshots/invalid/bad-namespace/output.js
@@ -3,7 +3,7 @@ module.exports = {
     type: "XMLDocument",
     rootElement: {
       type: "XMLElement",
-      namespaces: [],
+      namespaces: {},
       name: "table",
       attributes: [
         {
@@ -17,7 +17,7 @@ module.exports = {
       subElements: [
         {
           type: "XMLElement",
-          namespaces: [],
+          namespaces: {},
           name: "name",
           attributes: [],
           subElements: [],
@@ -40,7 +40,7 @@ module.exports = {
         },
         {
           type: "XMLElement",
-          namespaces: [],
+          namespaces: {},
           name: "width",
           attributes: [],
           subElements: [],
@@ -63,7 +63,7 @@ module.exports = {
         },
         {
           type: "XMLElement",
-          namespaces: [],
+          namespaces: {},
           name: "length",
           attributes: [],
           subElements: [],

--- a/packages/ast/test/snapshots/invalid/element-name-empty-last/output.js
+++ b/packages/ast/test/snapshots/invalid/element-name-empty-last/output.js
@@ -3,13 +3,13 @@ module.exports = {
     type: "XMLDocument",
     rootElement: {
       type: "XMLElement",
-      namespaces: [],
+      namespaces: {},
       name: "note",
       attributes: [],
       subElements: [
         {
           type: "XMLElement",
-          namespaces: [],
+          namespaces: {},
           name: "to",
           attributes: [],
           subElements: [],
@@ -31,7 +31,7 @@ module.exports = {
         },
         {
           type: "XMLElement",
-          namespaces: [],
+          namespaces: {},
           name: "from",
           attributes: [],
           subElements: [],
@@ -53,7 +53,7 @@ module.exports = {
         },
         {
           type: "XMLElement",
-          namespaces: [],
+          namespaces: {},
           name: null,
           attributes: [],
           subElements: [],

--- a/packages/ast/test/snapshots/invalid/element-name-empty-middle-comment/output.js
+++ b/packages/ast/test/snapshots/invalid/element-name-empty-middle-comment/output.js
@@ -3,13 +3,13 @@ module.exports = {
     type: "XMLDocument",
     rootElement: {
       type: "XMLElement",
-      namespaces: [],
+      namespaces: {},
       name: "note",
       attributes: [],
       subElements: [
         {
           type: "XMLElement",
-          namespaces: [],
+          namespaces: {},
           name: "to",
           attributes: [],
           subElements: [],
@@ -31,7 +31,7 @@ module.exports = {
         },
         {
           type: "XMLElement",
-          namespaces: [],
+          namespaces: {},
           name: null,
           attributes: [],
           subElements: [],
@@ -41,7 +41,7 @@ module.exports = {
         },
         {
           type: "XMLElement",
-          namespaces: [],
+          namespaces: {},
           name: "from",
           attributes: [],
           subElements: [],

--- a/packages/ast/test/snapshots/invalid/element-name-empty-middle/output.js
+++ b/packages/ast/test/snapshots/invalid/element-name-empty-middle/output.js
@@ -3,13 +3,13 @@ module.exports = {
     type: "XMLDocument",
     rootElement: {
       type: "XMLElement",
-      namespaces: [],
+      namespaces: {},
       name: "note",
       attributes: [],
       subElements: [
         {
           type: "XMLElement",
-          namespaces: [],
+          namespaces: {},
           name: "to",
           attributes: [],
           subElements: [],
@@ -31,7 +31,7 @@ module.exports = {
         },
         {
           type: "XMLElement",
-          namespaces: [],
+          namespaces: {},
           name: null,
           attributes: [],
           subElements: [],
@@ -41,7 +41,7 @@ module.exports = {
         },
         {
           type: "XMLElement",
-          namespaces: [],
+          namespaces: {},
           name: "from",
           attributes: [],
           subElements: [],

--- a/packages/ast/test/snapshots/invalid/element-name-last/output.js
+++ b/packages/ast/test/snapshots/invalid/element-name-last/output.js
@@ -3,13 +3,13 @@ module.exports = {
     type: "XMLDocument",
     rootElement: {
       type: "XMLElement",
-      namespaces: [],
+      namespaces: {},
       name: "note",
       attributes: [],
       subElements: [
         {
           type: "XMLElement",
-          namespaces: [],
+          namespaces: {},
           name: "to",
           attributes: [],
           subElements: [],
@@ -31,7 +31,7 @@ module.exports = {
         },
         {
           type: "XMLElement",
-          namespaces: [],
+          namespaces: {},
           name: "from",
           attributes: [],
           subElements: [],
@@ -53,7 +53,7 @@ module.exports = {
         },
         {
           type: "XMLElement",
-          namespaces: [],
+          namespaces: {},
           name: "ad",
           attributes: [],
           subElements: [],

--- a/packages/ast/test/snapshots/invalid/element-name-middle/output.js
+++ b/packages/ast/test/snapshots/invalid/element-name-middle/output.js
@@ -3,13 +3,13 @@ module.exports = {
     type: "XMLDocument",
     rootElement: {
       type: "XMLElement",
-      namespaces: [],
+      namespaces: {},
       name: "note",
       attributes: [],
       subElements: [
         {
           type: "XMLElement",
-          namespaces: [],
+          namespaces: {},
           name: "to",
           attributes: [],
           subElements: [],
@@ -31,7 +31,7 @@ module.exports = {
         },
         {
           type: "XMLElement",
-          namespaces: [],
+          namespaces: {},
           name: "ad",
           attributes: [],
           subElements: [],
@@ -44,7 +44,7 @@ module.exports = {
         },
         {
           type: "XMLElement",
-          namespaces: [],
+          namespaces: {},
           name: "from",
           attributes: [],
           subElements: [],
@@ -66,7 +66,7 @@ module.exports = {
         },
         {
           type: "XMLElement",
-          namespaces: [],
+          namespaces: {},
           name: "city",
           attributes: [],
           subElements: [],

--- a/packages/ast/test/snapshots/valid/attributes/output.js
+++ b/packages/ast/test/snapshots/valid/attributes/output.js
@@ -3,7 +3,7 @@ module.exports = {
     type: "XMLDocument",
     rootElement: {
       type: "XMLElement",
-      namespaces: [],
+      namespaces: {},
       name: "note",
       attributes: [
         {

--- a/packages/ast/test/snapshots/valid/complex-contents/output.js
+++ b/packages/ast/test/snapshots/valid/complex-contents/output.js
@@ -3,7 +3,7 @@ module.exports = {
     type: "XMLDocument",
     rootElement: {
       type: "XMLElement",
-      namespaces: [],
+      namespaces: {},
       name: "note",
       attributes: [],
       subElements: [],

--- a/packages/ast/test/snapshots/valid/elements-short-form/output.js
+++ b/packages/ast/test/snapshots/valid/elements-short-form/output.js
@@ -3,13 +3,13 @@ module.exports = {
     type: "XMLDocument",
     rootElement: {
       type: "XMLElement",
-      namespaces: [],
+      namespaces: {},
       name: "note",
       attributes: [],
       subElements: [
         {
           type: "XMLElement",
-          namespaces: [],
+          namespaces: {},
           name: "to",
           attributes: [],
           subElements: [],
@@ -31,7 +31,7 @@ module.exports = {
         },
         {
           type: "XMLElement",
-          namespaces: [],
+          namespaces: {},
           name: "from",
           attributes: [
             {

--- a/packages/ast/test/snapshots/valid/elements/output.js
+++ b/packages/ast/test/snapshots/valid/elements/output.js
@@ -3,13 +3,13 @@ module.exports = {
     type: "XMLDocument",
     rootElement: {
       type: "XMLElement",
-      namespaces: [],
+      namespaces: {},
       name: "note",
       attributes: [],
       subElements: [
         {
           type: "XMLElement",
-          namespaces: [],
+          namespaces: {},
           name: "to",
           attributes: [],
           subElements: [],
@@ -31,7 +31,7 @@ module.exports = {
         },
         {
           type: "XMLElement",
-          namespaces: [],
+          namespaces: {},
           name: "from",
           attributes: [],
           subElements: [],

--- a/packages/ast/test/snapshots/valid/namespaces/output.js
+++ b/packages/ast/test/snapshots/valid/namespaces/output.js
@@ -3,10 +3,10 @@ module.exports = {
     type: "XMLDocument",
     rootElement: {
       type: "XMLElement",
-      namespaces: [
-        { uri: "https://blah.com/furniture", prefix: "f" },
-        { uri: "https://blah.com/default" }
-      ],
+      namespaces: {
+        f: "https://blah.com/furniture",
+        "::DEFAULT": "https://blah.com/default"
+      },
       name: "table",
       attributes: [
         {
@@ -41,10 +41,10 @@ module.exports = {
       subElements: [
         {
           type: "XMLElement",
-          namespaces: [
-            { uri: "https://blah.com/furniture", prefix: "f" },
-            { uri: "https://blah.com/default" }
-          ],
+          namespaces: {
+            f: "https://blah.com/furniture",
+            "::DEFAULT": "https://blah.com/default"
+          },
           name: "name",
           attributes: [],
           subElements: [],
@@ -67,10 +67,10 @@ module.exports = {
         },
         {
           type: "XMLElement",
-          namespaces: [
-            { uri: "https://blah.com/furniture", prefix: "f" },
-            { uri: "https://blah.com/default" }
-          ],
+          namespaces: {
+            f: "https://blah.com/furniture",
+            "::DEFAULT": "https://blah.com/default"
+          },
           name: "width",
           attributes: [],
           subElements: [],
@@ -93,10 +93,10 @@ module.exports = {
         },
         {
           type: "XMLElement",
-          namespaces: [
-            { uri: "https://blah.com/furniture", prefix: "f" },
-            { uri: "https://blah.com/default" }
-          ],
+          namespaces: {
+            f: "https://blah.com/furniture",
+            "::DEFAULT": "https://blah.com/default"
+          },
           name: "length",
           attributes: [],
           subElements: [],
@@ -119,10 +119,10 @@ module.exports = {
         },
         {
           type: "XMLElement",
-          namespaces: [
-            { uri: "https://blah.com/furniture", prefix: "f" },
-            { uri: "https://blah.com/default" }
-          ],
+          namespaces: {
+            f: "https://blah.com/furniture",
+            "::DEFAULT": "https://blah.com/default"
+          },
           name: "description",
           attributes: [],
           subElements: [],

--- a/packages/ast/test/snapshots/valid/prolog-no-attriibs/output.js
+++ b/packages/ast/test/snapshots/valid/prolog-no-attriibs/output.js
@@ -3,13 +3,13 @@ module.exports = {
     type: "XMLDocument",
     rootElement: {
       type: "XMLElement",
-      namespaces: [],
+      namespaces: {},
       name: "note",
       attributes: [],
       subElements: [
         {
           type: "XMLElement",
-          namespaces: [],
+          namespaces: {},
           name: "to",
           attributes: [],
           subElements: [],
@@ -31,7 +31,7 @@ module.exports = {
         },
         {
           type: "XMLElement",
-          namespaces: [],
+          namespaces: {},
           name: "from",
           attributes: [],
           subElements: [],

--- a/packages/ast/test/snapshots/valid/prolog/output.js
+++ b/packages/ast/test/snapshots/valid/prolog/output.js
@@ -3,7 +3,7 @@ module.exports = {
     type: "XMLDocument",
     rootElement: {
       type: "XMLElement",
-      namespaces: [],
+      namespaces: {},
       name: "note",
       attributes: [],
       subElements: [],

--- a/packages/simple-schema/test/content-assist/element-name-spec.js
+++ b/packages/simple-schema/test/content-assist/element-name-spec.js
@@ -192,6 +192,7 @@ describe("The XML Simple Schema", () => {
         ]);
         expect(suggestions).to.have.lengthOf(2);
       });
+
       it("allows multiple sub-elements with `multiple` cardinality", () => {
         const xmlText = `<people>
                     <person>
@@ -249,6 +250,7 @@ describe("The XML Simple Schema", () => {
         expect(suggestions).to.have.lengthOf(1);
       });
     });
+
     it("does not crash if there is no xss element", () => {
       const xmlText = `<people>
                     <person>
@@ -269,7 +271,8 @@ describe("The XML Simple Schema", () => {
       expect(suggestions).to.deep.include.members([]);
       expect(suggestions).to.have.lengthOf(0);
     });
-    it("nested elements with namespces", () => {
+
+    it("nested elements with namespaces", () => {
       const xmlText = `<abc:people xmlns:abc="http://namespace.com/1">
                     <person xmlns="http://namespace.com/2">
                       <⇶
@@ -342,6 +345,7 @@ describe("The XML Simple Schema", () => {
       ]);
       expect(suggestions).to.have.lengthOf(4);
     });
+
     it("with namespace prefix", () => {
       const xmlText = `<abc:people xmlns:abc="http://namespace.com/1">
                     <person xmlns="http://namespace.com/2">
@@ -405,6 +409,7 @@ describe("The XML Simple Schema", () => {
       ]);
       expect(suggestions).to.have.lengthOf(2);
     });
+
     it("should not crash with invalid prefix", () => {
       const xmlText = `<abc:people xmlns:abc="http://namespace.com/1">
                     <person xmlns="http://namespace.com/2">


### PR DESCRIPTION
namespaces are no longer modeled as an array of objects, instead it is a map where the key
represents the `prefix` and the value is the `uri.

BREAKING CHANGE: The `namespaces` property of an XMLElement is now a Map/Dictionary not an Array.