### PR TITLE
chore(xml-for-vscode): use version range in `engines` for VSCode dep

### DIFF
--- a/packages/xml-for-vscode/package.json
+++ b/packages/xml-for-vscode/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/SAP/xml-tools"
   },
   "engines": {
-    "vscode": "1.42.1"
+    "vscode": "^1.42.1"
   },
   "activationEvents": [
     "onLanguage:xml"


### PR DESCRIPTION
Otherwise:

1. Need to manually update it each time a new VSCode version is released.
2. Integration Tests would fail as they download the **latest** VSCode version.