### PR TITLE
chore(ast-position): cr fixes for ast-position

### DIFF
--- a/packages/ast-position/CONTRIBUTING.md
+++ b/packages/ast-position/CONTRIBUTING.md
@@ -1,0 +1,4 @@
+# Contribution Guide
+
+This package does not have any unique development flows.
+Please see the top level [Contribution Guide](../../CONTRIBUTING.md).

--- a/packages/ast-position/README.md
+++ b/packages/ast-position/README.md
@@ -1,0 +1,37 @@
+[![npm (scoped)](https://img.shields.io/npm/v/@xml-tools/ast-position.svg)](https://www.npmjs.com/package/@xml-tools/ast-position)
+
+# @xml-tools/ast-position
+
+Utilities related to textual positions in the XML-Tools **A**bstract **S**yntax **T**ree.
+
+## Installation
+
+With npm:
+
+- `npm install @xml-tools/ast-position`
+
+With Yarn
+
+- `yarn add @xml-tools/ast-position`
+
+## Usage
+
+Please see the [TypeScript Definitions](./api.d.ts) for full API details.
+
+Simply import/require the @xml-tools/ast-position package and use the utilities
+as defined in the APIs above.
+
+## Support
+
+Please open [issues](https://github.com/SAP/xml-tols/issues) on github.
+
+## Contributing
+
+See [CONTRIBUTING.md](./CONTRIBUTING.md).
+
+## License
+
+Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the [LICENSE file](../../LICENSE).
+
+[ast]: https://en.wikipedia.org/wiki/Abstract_syntax_tree

--- a/packages/ast-position/api.d.ts
+++ b/packages/ast-position/api.d.ts
@@ -1,5 +1,20 @@
 import { XMLAttribute, XMLElement, XMLDocument } from "@xml-tools/ast";
 
+/**
+ * Not all possible kinds of positions are currently supported.
+ * More may be added in the future.
+ */
+type AstPosition =
+  | XMLElementOpenName
+  | XMLElementCloseName
+  | XMLAttributeKey
+  | XMLAttributeValue;
+
+declare function astPositionAtOffset(
+  ast: XMLDocument,
+  offset: number
+): AstPosition | undefined;
+
 interface XMLElementOpenName {
   kind: "XMLElementOpenName";
   astNode: XMLElement;
@@ -19,13 +34,3 @@ interface XMLAttributeValue {
   kind: "XMLAttributeValue";
   astNode: XMLAttribute;
 }
-
-declare function getAstNodeInPosition(
-  ast: XMLDocument,
-  offset: number
-):
-  | XMLElementOpenName
-  | XMLElementCloseName
-  | XMLAttributeKey
-  | XMLAttributeValue
-  | undefined;

--- a/packages/ast-position/lib/api.js
+++ b/packages/ast-position/lib/api.js
@@ -1,12 +1,17 @@
 const { AstPositionVisitor } = require("./ast-position");
 const { accept } = require("@xml-tools/ast");
 
-function getAstNodeInPosition(ast, offset) {
-  const visitor = new AstPositionVisitor(offset);
-  accept(ast, visitor);
-  return visitor.astContext;
+/**
+ * @param {XMLDocument} xmlDoc
+ * @param {number} offset
+ * @returns {AstPosition | undefined}
+ */
+function astPositionAtOffset(xmlDoc, offset) {
+  const positionVisitor = new AstPositionVisitor(offset);
+  accept(xmlDoc, positionVisitor);
+  return positionVisitor.position;
 }
 
 module.exports = {
-  getAstNodeInPosition: getAstNodeInPosition
+  astPositionAtOffset
 };

--- a/packages/ast-position/lib/ast-position.js
+++ b/packages/ast-position/lib/ast-position.js
@@ -1,14 +1,16 @@
 class AstPositionVisitor {
   constructor(offset) {
     this.offset = offset;
+    this.position = undefined;
   }
+
   visitXMLElement(node) {
     const openName = node.syntax.openName;
     const closeName = node.syntax.closeName;
     if (this.isOffsetInRange(openName)) {
-      this.astContext = { kind: "XMLElementOpenName", astNode: node };
+      this.position = { kind: "XMLElementOpenName", astNode: node };
     } else if (this.isOffsetInRange(closeName)) {
-      this.astContext = { kind: "XMLElementCloseName", astNode: node };
+      this.position = { kind: "XMLElementCloseName", astNode: node };
     }
   }
 
@@ -17,9 +19,9 @@ class AstPositionVisitor {
     const value = node.syntax.value;
 
     if (this.isOffsetInRange(key)) {
-      this.astContext = { kind: "XMLAttributeKey", astNode: node };
+      this.position = { kind: "XMLAttributeKey", astNode: node };
     } else if (this.isOffsetInRange(value)) {
-      this.astContext = { kind: "XMLAttributeValue", astNode: node };
+      this.position = { kind: "XMLAttributeValue", astNode: node };
     }
   }
 

--- a/packages/ast-position/package.json
+++ b/packages/ast-position/package.json
@@ -11,10 +11,10 @@
   "license": "Apache-2.0",
   "typings": "./api.d.ts",
   "dependencies": {
-    "@xml-tools/ast": "4.1.0"
+    "@xml-tools/ast": "^4.2.0"
   },
   "devDependencies": {
-    "vscode-languageserver": "6.1.1"
+    "@xml-tools/parser": "^1.0.5"
   },
   "scripts": {
     "ci": "npm-run-all type-check coverage:*",

--- a/packages/ast-position/test/ast-position-spec.js
+++ b/packages/ast-position/test/ast-position-spec.js
@@ -1,18 +1,19 @@
 const { expect } = require("chai");
-const { TextDocument } = require("vscode-languageserver");
 const { buildAst } = require("@xml-tools/ast");
 const { parse } = require("@xml-tools/parser");
-const { getAstNodeInPosition } = require("../lib/api");
+// Testing the npm package `main` exports by requiring the folder where the `package.json` resides.
+const { astPositionAtOffset } = require("../");
 
 describe("AST Position visitor", () => {
   it("will get xml attribute key", () => {
     const xmlSnippet = `
-    <mvc:View 
-      xmlns:mvc="sap.ui.core.mvc" 
-      xmlns="sap.m"> 
-      <List showSeparat⇶ors = "All"></List>
-    </mvc:View>`;
-    const astNodeInPosition = getXMLNodeFromVisitor(xmlSnippet);
+      <mvc:View 
+        xmlns:mvc="sap.ui.core.mvc" 
+        xmlns="sap.m"> 
+        <List showSeparat⇶ors = "All"></List>
+      </mvc:View>`;
+    const astNodeInPosition = getXMLPositionFromSnippet(xmlSnippet);
+
     expect(astNodeInPosition).to.exist;
     expect(astNodeInPosition.kind).to.equal("XMLAttributeKey");
     expect(astNodeInPosition.astNode.key).to.equal("showSeparators");
@@ -20,12 +21,13 @@ describe("AST Position visitor", () => {
 
   it("will get xml attribute value", () => {
     const xmlSnippet = `
-    <mvc:View 
-      xmlns:mvc="sap.ui.core.mvc" 
-      xmlns="sap.m"> 
-      <List showSeparators = "All⇶"></List>
-    </mvc:View>`;
-    const astNodeInPosition = getXMLNodeFromVisitor(xmlSnippet);
+      <mvc:View 
+        xmlns:mvc="sap.ui.core.mvc" 
+        xmlns="sap.m"> 
+        <List showSeparators = "All⇶"></List>
+      </mvc:View>`;
+    const astNodeInPosition = getXMLPositionFromSnippet(xmlSnippet);
+
     expect(astNodeInPosition).to.exist;
     expect(astNodeInPosition.kind).to.equal("XMLAttributeValue");
     expect(astNodeInPosition.astNode.value).to.equal("All");
@@ -33,12 +35,13 @@ describe("AST Position visitor", () => {
 
   it("will get xml element open name", () => {
     const xmlSnippet = `
-    <mvc:View 
-      xmlns:mvc="sap.ui.core.mvc" 
-      xmlns="sap.m"> 
-      <Lis⇶t></List>
-    </mvc:View>`;
-    const astNodeInPosition = getXMLNodeFromVisitor(xmlSnippet);
+      <mvc:View 
+        xmlns:mvc="sap.ui.core.mvc" 
+        xmlns="sap.m"> 
+        <Lis⇶t></List>
+      </mvc:View>`;
+    const astNodeInPosition = getXMLPositionFromSnippet(xmlSnippet);
+
     expect(astNodeInPosition).to.exist;
     expect(astNodeInPosition.kind).to.equal("XMLElementOpenName");
     expect(astNodeInPosition.astNode.name).to.equal("List");
@@ -46,12 +49,13 @@ describe("AST Position visitor", () => {
 
   it("will get xml element close name", () => {
     const xmlSnippet = `
-    <mvc:View 
-      xmlns:mvc="sap.ui.core.mvc" 
-      xmlns="sap.m"> 
-      <customData></customDa⇶ta>
-    </mvc:View>`;
-    const astNodeInPosition = getXMLNodeFromVisitor(xmlSnippet);
+      <mvc:View 
+        xmlns:mvc="sap.ui.core.mvc" 
+        xmlns="sap.m"> 
+        <customData></customDa⇶ta>
+      </mvc:View>`;
+    const astNodeInPosition = getXMLPositionFromSnippet(xmlSnippet);
+
     expect(astNodeInPosition).to.exist;
     expect(astNodeInPosition.kind).to.equal("XMLElementCloseName");
     expect(astNodeInPosition.astNode.name).to.equal("customData");
@@ -59,79 +63,81 @@ describe("AST Position visitor", () => {
 
   it("Out of element - before open tag", () => {
     const xmlSnippet = `
-    ⇶<mvc:View 
-      xmlns:mvc="sap.ui.core.mvc" 
-      xmlns="sap.m"> 
-      <List></List>
-    </mvc:View>`;
-    const astNodeInPosition = getXMLNodeFromVisitor(xmlSnippet);
-    expect(astNodeInPosition).to.not.exist;
+      ⇶<mvc:View 
+        xmlns:mvc="sap.ui.core.mvc" 
+        xmlns="sap.m"> 
+        <List></List>
+      </mvc:View>`;
+
+    const astNodeInPosition = getXMLPositionFromSnippet(xmlSnippet);
+    expect(astNodeInPosition).to.be.undefined;
   });
 
   it("Out of element - after close tag", () => {
     const xmlSnippet = `
-    <mvc:View 
-      xmlns:mvc="sap.ui.core.mvc" 
-      xmlns="sap.m"> 
-      <List></List>
-    </mvc:View>⇶`;
-    const astNodeInPosition = getXMLNodeFromVisitor(xmlSnippet);
-    expect(astNodeInPosition).to.not.exist;
+      <mvc:View 
+        xmlns:mvc="sap.ui.core.mvc" 
+        xmlns="sap.m"> 
+        <List></List>
+      </mvc:View>⇶`;
+
+    const astNodeInPosition = getXMLPositionFromSnippet(xmlSnippet);
+    expect(astNodeInPosition).to.be.undefined;
   });
 
   it("Out of element - between elements", () => {
     const xmlSnippet = `
-    <mvc:View 
-      xmlns:mvc="sap.ui.core.mvc" 
-      xmlns="sap.m"> 
-      <List>⇶</List>
-    </mvc:View>`;
-    const astNodeInPosition = getXMLNodeFromVisitor(xmlSnippet);
-    expect(astNodeInPosition).to.not.exist;
+      <mvc:View 
+        xmlns:mvc="sap.ui.core.mvc" 
+        xmlns="sap.m"> 
+        <List>⇶</List>
+      </mvc:View>`;
+
+    const astNodeInPosition = getXMLPositionFromSnippet(xmlSnippet);
+    expect(astNodeInPosition).to.be.undefined;
   });
 
   it("Out of attribute - before attribute", () => {
     const xmlSnippet = `
-    <mvc:View 
-      xmlns:mvc="sap.ui.core.mvc" 
-      xmlns="sap.m"> 
-      <List ⇶ showSeparators = "All"></List>
-    </mvc:View>`;
-    const astNodeInPosition = getXMLNodeFromVisitor(xmlSnippet);
-    expect(astNodeInPosition).to.not.exist;
+      <mvc:View 
+        xmlns:mvc="sap.ui.core.mvc" 
+        xmlns="sap.m"> 
+        <List ⇶ showSeparators = "All"></List>
+      </mvc:View>`;
+
+    const astNodeInPosition = getXMLPositionFromSnippet(xmlSnippet);
+    expect(astNodeInPosition).to.be.undefined;
   });
 
   it("Out of attribute - between attributes", () => {
     const xmlSnippet = `
-    <mvc:View 
-      xmlns:mvc="sap.ui.core.mvc" 
-      xmlns="sap.m"> 
-      <List showSeparators = "All"⇶ busy="false"></List>
-    </mvc:View>`;
-    const astNodeInPosition = getXMLNodeFromVisitor(xmlSnippet);
-    expect(astNodeInPosition).to.not.exist;
+      <mvc:View 
+        xmlns:mvc="sap.ui.core.mvc" 
+        xmlns="sap.m"> 
+        <List showSeparators = "All"⇶ busy="false"></List>
+      </mvc:View>`;
+
+    const astNodeInPosition = getXMLPositionFromSnippet(xmlSnippet);
+    expect(astNodeInPosition).to.be.undefined;
   });
 
   it("Out of attribute - between key to vale", () => {
     const xmlSnippet = `
-    <mvc:View 
-      xmlns:mvc="sap.ui.core.mvc" 
-      xmlns="sap.m"> 
-      <List showSeparators =⇶ "All"></List>
-    </mvc:View>`;
-    const astNodeInPosition = getXMLNodeFromVisitor(xmlSnippet);
-    expect(astNodeInPosition).to.not.exist;
+      <mvc:View 
+        xmlns:mvc="sap.ui.core.mvc" 
+        xmlns="sap.m"> 
+        <List showSeparators =⇶ "All"></List>
+      </mvc:View>`;
+
+    const astNodeInPosition = getXMLPositionFromSnippet(xmlSnippet);
+    expect(astNodeInPosition).to.be.undefined;
   });
 
-  function createTextDocument(languageId, content) {
-    return TextDocument.create("uri", languageId, 0, content);
-  }
-
-  function getXMLNodeFromVisitor(xmlSnippet) {
+  function getXMLPositionFromSnippet(xmlSnippet) {
     const xmlText = xmlSnippet.replace("⇶", "");
     const offset = xmlSnippet.indexOf("⇶");
     const { cst, tokenVector } = parse(xmlText);
-    const ast = buildAst(cst, tokenVector);
-    return getAstNodeInPosition(ast, offset);
+    const xmlDoc = buildAst(cst, tokenVector);
+    return astPositionAtOffset(xmlDoc, offset);
   }
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1164,22 +1164,6 @@
   resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.45.0.tgz#8a07e740aa1ca7264da8cb17be87b733836d6c01"
   integrity sha512-b0Gyir7sPBCqiKLygAhn/AYVfzWD+SMPkWltBrIuPEyTOxSU1wVApWY/FcxYO2EWTRacoubTl4+gvZf86RkecA==
 
-"@xml-tools/ast@4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@xml-tools/ast/-/ast-4.1.0.tgz#2660783c9f9a600ed0c9e33bf8919542fb2be531"
-  integrity sha512-8nErsCzkk8PtRI3XP+FgSs3ZINtlR+Jr39zO73xc23VX8ASaNmdEtRgjWVXHC8aWGU1KAw+BWXmB2fVz19YCXQ==
-  dependencies:
-    "@xml-tools/common" "^0.0.6"
-    "@xml-tools/parser" "^1.0.4"
-    lodash "4.17.15"
-
-"@xml-tools/common@^0.0.6":
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/@xml-tools/common/-/common-0.0.6.tgz#0932d44ecb65fdfea7ac597126b60f9aa37695b0"
-  integrity sha512-d/iouioRW4RXKvzE6RqY5b8ba0RSBeQgFoUrL44MdUzR9JBpdXO3TMLwNYdEKCBJGtCpi7/LiwseBNCGTNIMcw==
-  dependencies:
-    lodash "4.17.15"
-
 "@zkochan/cmd-shim@^3.1.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@zkochan/cmd-shim/-/cmd-shim-3.1.0.tgz#2ab8ed81f5bb5452a85f25758eb9b8681982fd2e"


### PR DESCRIPTION
- remove un-used test utility.
- remove un-used dev-dep.
- added needed dev dep (parser)
- fix dep version to "ast" package to point to latest version, otherwise
  multiple versions of @xml-tools/ast would exist in this
  mono-repo (and yarn.lock).
- Better name to the main exported utility.
- Re-arranged api.d.ts and declared a separate type for `AstPosition`
- Minor naming in the PositionVisitor/Tests
- Better formatting for xml snippets.
- Better assertions to explicitly match expected value when the position does not exist (is undefined).
