### PR TITLE
feat(ast): attribute inside a prolog are now of XMLPrologAttribute type

### DIFF
--- a/packages/ast/api.d.ts
+++ b/packages/ast/api.d.ts
@@ -39,7 +39,7 @@ declare interface XMLProlog {
   readonly type: "XMLProlog";
   readonly parent: XMLDocument;
 
-  readonly attributes: XMLAttribute[];
+  readonly attributes: XMLPrologAttribute[];
 
   readonly position: SourcePosition;
 }
@@ -135,9 +135,8 @@ declare interface XMLTextContent {
   readonly position: SourcePosition;
 }
 
-declare interface XMLAttribute {
-  readonly type: "XMLAttribute";
-  readonly parent: XMLElement;
+declare interface XMLAttributeBase {
+  readonly type: string;
 
   readonly key: string | InvalidSyntax;
   // Semantic Value: Would not include the quotes!
@@ -149,6 +148,22 @@ declare interface XMLAttribute {
     readonly value?: XMLToken;
   };
   readonly position: SourcePosition;
+}
+
+declare interface XMLAttribute extends XMLAttributeBase {
+  readonly type: "XMLAttribute";
+  readonly parent: XMLElement;
+}
+
+/**
+ * XMLPrologAttribute is virtually identical to a regular `XMLAttribute`.
+ * However it was moved to a separate interface to allow consistent handling of the `parent`
+ * property in `XMLAttribute`, as 99.9% of the time the edge case of a parent being an XMLProlog
+ * is not relevant.
+ */
+declare interface XMLPrologAttribute extends XMLAttributeBase {
+  readonly type: "XMLPrologAttribute";
+  readonly parent: XMLProlog;
 }
 
 declare interface SourceRange {
@@ -172,6 +187,7 @@ declare interface XMLToken extends SourcePosition {
 declare type XMLAstNode =
   | XMLDocument
   | XMLProlog
+  | XMLPrologAttribute
   | XMLElement
   | XMLAttribute
   | XMLTextContent;
@@ -191,6 +207,7 @@ declare function accept(node: XMLAstNode, visitor: XMLAstVisitor): void;
 declare interface XMLAstVisitor {
   visitXMLDocument?(node: XMLDocument): void;
   visitXMLProlog?(node: XMLProlog): void;
+  visitXMLPrologAttribute?(node: XMLPrologAttribute): void;
   visitXMLElement?(node: XMLElement): void;
   visitXMLAttribute?(node: XMLAttribute): void;
   visitXMLTextContent?(node: XMLTextContent): void;

--- a/packages/ast/lib/build-ast.js
+++ b/packages/ast/lib/build-ast.js
@@ -43,17 +43,18 @@ class CstToAstVisitor extends BaseXmlCstVisitor {
     this.tokenVector = tokenVector;
   }
 
-  visit(cstNode) {
-    return super.visit(cstNode, cstNode.location);
+  visit(cstNode, params = {}) {
+    return super.visit(cstNode, { location: cstNode.location, ...params });
   }
 
   /**
    * @param ctx {DocumentCtx}
-   * @param location {SourcePosition}
+   * @param opts {Object}
+   * @param opts.location {SourcePosition}
    *
    * @returns {XMLDocument}
    */
-  document(ctx, location) {
+  document(ctx, { location }) {
     const astNode = {
       type: "XMLDocument",
       rootElement: invalidSyntax,
@@ -78,9 +79,10 @@ class CstToAstVisitor extends BaseXmlCstVisitor {
 
   /**
    * @param ctx {PrologCtx}
-   * @param location {SourcePosition}
+   * @param opts {Object}
+   * @param opts.location {SourcePosition}
    */
-  prolog(ctx, location) {
+  prolog(ctx, { location }) {
     const astNode = {
       type: "XMLProlog",
       attributes: [],
@@ -88,7 +90,9 @@ class CstToAstVisitor extends BaseXmlCstVisitor {
     };
 
     if (ctx.attribute !== undefined) {
-      astNode.attributes = map(ctx.attribute, this.visit.bind(this));
+      astNode.attributes = map(ctx.attribute, (_) =>
+        this.visit(_, { isPrologParent: true })
+      );
     }
 
     setChildrenParent(astNode);
@@ -110,11 +114,12 @@ class CstToAstVisitor extends BaseXmlCstVisitor {
 
   /**
    * @param ctx {ContentCtx}
-   * @param location {SourcePosition}
+   * @param opts {Object}
+   * @param opts.location {SourcePosition}
    *
    * @return {{elements, textContents}}
    */
-  content(ctx, location) {
+  content(ctx, { location }) {
     let elements = [];
     let textContents = [];
 
@@ -131,9 +136,10 @@ class CstToAstVisitor extends BaseXmlCstVisitor {
 
   /**
    * @param ctx {ElementCtx}
-   * @param location {SourcePosition}
+   * @param opts {Object}
+   * @param opts.location {SourcePosition}
    */
-  element(ctx, location) {
+  element(ctx, { location }) {
     const astNode = {
       type: "XMLElement",
       // Avoid Accidental Keys in this map
@@ -167,20 +173,23 @@ class CstToAstVisitor extends BaseXmlCstVisitor {
 
   /**
    * @param ctx {ReferenceCtx}
-   * @param location {SourcePosition}
+   * @param opts {Object}
+   * @param opts.location {SourcePosition}
    */
   /* istanbul ignore next - place holder*/
-  reference(ctx, location) {
+  reference(ctx, { location }) {
     // Irrelevant for the AST at this time
   }
 
   /**
    * @param ctx {AttributeCtx}
-   * @param location {SourcePosition}
+   * @param opts {Object}
+   * @param opts.location {SourcePosition}
+   * @param opts.isPrologParent {boolean}
    */
-  attribute(ctx, location) {
+  attribute(ctx, { location, isPrologParent }) {
     const astNode = {
-      type: "XMLAttribute",
+      type: isPrologParent ? "XMLPrologAttribute" : "XMLAttribute",
       position: location,
       key: invalidSyntax,
       value: invalidSyntax,
@@ -210,9 +219,10 @@ class CstToAstVisitor extends BaseXmlCstVisitor {
 
   /**
    * @param ctx {ChardataCtx}
-   * @param location {SourcePosition}
+   * @param opts {Object}
+   * @param opts.location {SourcePosition}
    */
-  chardata(ctx, location) {
+  chardata(ctx, { location }) {
     const astNode = {
       type: "XMLTextContent",
       position: location,
@@ -235,10 +245,11 @@ class CstToAstVisitor extends BaseXmlCstVisitor {
 
   /**
    * @param ctx {MiscCtx}
-   * @param location {SourcePosition}
+   * @param opts {Object}
+   * @param opts.location {SourcePosition}
    */
   /* istanbul ignore next - place holder*/
-  misc(ctx, location) {
+  misc(ctx, { location }) {
     // Irrelevant for the AST at this time
   }
 }

--- a/packages/ast/lib/visit-ast.js
+++ b/packages/ast/lib/visit-ast.js
@@ -21,6 +21,12 @@ function accept(node, visitor) {
       }
       break;
     }
+    case "XMLPrologAttribute": {
+      if (isFunction(visitor.visitXMLPrologAttribute)) {
+        visitor.visitXMLPrologAttribute(node);
+      }
+      break;
+    }
     case "XMLElement": {
       if (isFunction(visitor.visitXMLElement)) {
         visitor.visitXMLElement(node);

--- a/packages/ast/test/snapshots/invalid/missing-top-level-element/output.js
+++ b/packages/ast/test/snapshots/invalid/missing-top-level-element/output.js
@@ -7,7 +7,7 @@ module.exports = {
       type: "XMLProlog",
       attributes: [
         {
-          type: "XMLAttribute",
+          type: "XMLPrologAttribute",
           position: { startOffset: 6, endOffset: 18 },
           key: "version",
           value: "1.0",
@@ -17,7 +17,7 @@ module.exports = {
           },
         },
         {
-          type: "XMLAttribute",
+          type: "XMLPrologAttribute",
           position: { startOffset: 20, endOffset: 35 },
           key: "encoding",
           value: "UTF-8",

--- a/packages/ast/test/snapshots/valid/prolog/output.js
+++ b/packages/ast/test/snapshots/valid/prolog/output.js
@@ -23,7 +23,7 @@ module.exports = {
       type: "XMLProlog",
       attributes: [
         {
-          type: "XMLAttribute",
+          type: "XMLPrologAttribute",
           position: { startOffset: 6, endOffset: 18 },
           key: "version",
           value: "1.0",
@@ -33,7 +33,7 @@ module.exports = {
           },
         },
         {
-          type: "XMLAttribute",
+          type: "XMLPrologAttribute",
           position: { startOffset: 20, endOffset: 35 },
           key: "encoding",
           value: "UTF-8",

--- a/packages/ast/test/utils.js
+++ b/packages/ast/test/utils.js
@@ -24,6 +24,9 @@ const parentRemoverVisitor = {
   visitXMLProlog: (node) => {
     delete node.parent;
   },
+  visitXMLPrologAttribute: (node) => {
+    delete node.parent;
+  },
   visitXMLElement: (node) => {
     delete node.parent;
   },
@@ -43,6 +46,9 @@ const positionReducerVisitor = {
     reduceNodePoseInfo(node);
   },
   visitXMLProlog: (node) => {
+    reduceNodePoseInfo(node);
+  },
+  visitXMLPrologAttribute: (node) => {
     reduceNodePoseInfo(node);
   },
   visitXMLElement: (node) => {

--- a/packages/ast/test/visitor/visitor-spec.js
+++ b/packages/ast/test/visitor/visitor-spec.js
@@ -57,14 +57,35 @@ describe("The XML AST Visitor", () => {
     let visitedCounter = 0;
     const visitor = {
       visitXMLAttribute: function (node) {
-        expect(["foo", "bar", "version", "encoding"]).to.include(node.key);
+        expect(["foo", "bar"]).to.include(node.key);
         visitedCounter++;
       },
     };
 
     const astNode = getAst(inputText);
     accept(astNode, visitor);
-    expect(visitedCounter).to.eql(4);
+    expect(visitedCounter).to.eql(2);
+  });
+
+  it("can traverse AST Prolog Attributes", () => {
+    const inputText = `<?xml version="1.0" encoding="UTF-8"?>
+    <note>
+      <to foo="123">Bill</to>
+      <from bar="456">Tim</from>
+    </note>
+    `;
+
+    let visitedCounter = 0;
+    const visitor = {
+      visitXMLPrologAttribute: function (node) {
+        expect(["version", "encoding"]).to.include(node.key);
+        visitedCounter++;
+      },
+    };
+
+    const astNode = getAst(inputText);
+    accept(astNode, visitor);
+    expect(visitedCounter).to.eql(2);
   });
 
   it("can traverse AST Prolog", () => {

--- a/packages/simple-schema/lib/path.js
+++ b/packages/simple-schema/lib/path.js
@@ -1,14 +1,10 @@
-const { drop, dropRight, map, forEach, last, first } = require("lodash");
+const { drop, map, forEach, first } = require("lodash");
 
 /**
  * @param {XMLAttribute} attribNode
  * @param {SimpleSchema} schema
  */
 function findAttributeXssDef(attribNode, schema) {
-  // Currently No support for Prolog Attributes in Simple XML Schema
-  if (attribNode.parent && attribNode.parent.type === "XMLProlog") {
-    return undefined;
-  }
   const xssElement = findElementXssDef(attribNode.parent, schema);
 
   let xssAttribute = undefined;


### PR DESCRIPTION
The parent property of an `XMLAttribute` cannot be defined as type "XMLElement".
That is because a prolog may also contain attributes.

To enable consistent handling of the vastly more common use case of
XMLElements being the parents of XMLAttributes, Prolog attributes are now
marked with a special type "XMLPrologAttribute" with a separate interface
and a separate visitor method.

BREAKING CHANGE: Vistors that need to handle attributes inside prolog must now implement the `visitPrologAttribute` method.