### PR TITLE
fix: use relative chevrotain version

### DIFF
--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -29,7 +29,7 @@
     "vscode-languageserver-textdocument": "1.0.1"
   },
   "devDependencies": {
-    "chevrotain": "^7.0.1",
+    "chevrotain": "^7.1.0",
     "vscode-languageserver-types": "3.16.0"
   },
   "scripts": {

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -16,7 +16,7 @@
     "api.d.ts"
   ],
   "dependencies": {
-    "chevrotain": "7.0.1"
+    "chevrotain": "^7.1.0"
   },
   "devDependencies": {
     "klaw-sync": "6.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2015,10 +2015,10 @@ cheerio@^1.0.0-rc.1:
     lodash "^4.15.0"
     parse5 "^3.0.1"
 
-chevrotain@7.0.1, chevrotain@^7.0.1:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/chevrotain/-/chevrotain-7.0.1.tgz#55d1d21a9afea0aad23b4d30e75650212eb4cc9f"
-  integrity sha512-B/44jrdw5GAzy483LEeVSgXSX0qOYM8lUd3l5+yf6Vl6OQjEUCm2BUiYbHRCIK6xCEvCLAFe1kj8uyV6+zdaVw==
+chevrotain@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/chevrotain/-/chevrotain-7.1.0.tgz#a88d437e9950f66a452c3a575b764a01d0c8f189"
+  integrity sha512-msTqYIGb+8z4UpNxliBlowlfFJtBQjTSdnOWgMD/llcE5cQHDbFMjHGdCMJSsPG/Op89c6/ERCmYku4UHDhHVA==
   dependencies:
     regexp-to-ast "0.5.0"
 


### PR DESCRIPTION
Keeping chevrotain version relative would enable the consumer of these
packages to upgrade to chevrotain patch releases independently.

e.g. The following fix is a must for who uses webpack with minification.

https://github.com/SAP/chevrotain/pull/1269

Without this PR, it is not easily possible to upgrade chevrotain from
the consumer end.

This is a blocker for https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/issues/481