### PR TITLE
chore: use caret (^) range for lodash dependency

### DIFF
--- a/packages/ast/package.json
+++ b/packages/ast/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@xml-tools/common": "^0.1.6",
     "@xml-tools/parser": "^1.0.11",
-    "lodash": "4.17.21"
+    "lodash": "^4.17.21"
   },
   "devDependencies": {
     "klaw-sync": "6.0.0"

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -17,7 +17,7 @@
     "api.d.ts"
   ],
   "dependencies": {
-    "lodash": "4.17.21"
+    "lodash": "^4.17.21"
   },
   "devDependencies": {
     "@xml-tools/parser": "^1.0.11"

--- a/packages/constraints/package.json
+++ b/packages/constraints/package.json
@@ -18,7 +18,7 @@
   ],
   "dependencies": {
     "@xml-tools/validation": "^1.0.16",
-    "lodash": "4.17.21"
+    "lodash": "^4.17.21"
   },
   "devDependencies": {
     "@xml-tools/ast": "^5.0.5"

--- a/packages/content-assist/package.json
+++ b/packages/content-assist/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@xml-tools/common": "^0.1.6",
     "@xml-tools/parser": "^1.0.11",
-    "lodash": "4.17.21"
+    "lodash": "^4.17.21"
   },
   "scripts": {
     "ci": "npm-run-all clean type-check coverage:*",

--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@xml-tools/constraints": "^1.1.1",
     "@xml-tools/parser": "^1.0.11",
-    "lodash": "4.17.21",
+    "lodash": "^4.17.21",
     "vscode-languageserver": "7.0.0",
     "vscode-languageserver-textdocument": "1.0.1"
   },

--- a/packages/simple-schema/package.json
+++ b/packages/simple-schema/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@xml-tools/ast": "^5.0.5",
     "@xml-tools/content-assist": "^3.1.11",
-    "lodash": "4.17.21"
+    "lodash": "^4.17.21"
   },
   "devDependencies": {
     "@xml-tools/parser": "^1.0.11",

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -18,7 +18,7 @@
   ],
   "dependencies": {
     "@xml-tools/ast": "^5.0.5",
-    "lodash": "4.17.21"
+    "lodash": "^4.17.21"
   },
   "devDependencies": {
     "@xml-tools/parser": "^1.0.11"

--- a/packages/xml-toolkit/package.json
+++ b/packages/xml-toolkit/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@types/vscode": "1.56.0",
     "deep-equal-in-any-order": "1.0.28",
-    "lodash": "4.17.21",
+    "lodash": "^4.17.21",
     "proxyquire": "2.1.3",
     "vsce": "1.84.0",
     "vscode-test": "1.5.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4874,7 +4874,7 @@ lodash.truncate@^4.4.2:
   resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
   integrity sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=
 
-lodash@4.17.21, lodash@^4.17.12, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.7.0:
+lodash@^4.17.12, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==


### PR DESCRIPTION
This PR changes dependency `lodash: 4.17.21` with `lodash: ^4.17.21` in all `package.json`.

Using a range will allow consumers of these libraries to deduplicate `lodash`. For example, if my project happens to have `lodash@4.17.22` already, I can use that version to satisfy the dependency requirements of `@xml-tools/*` packages. This is specially important if I'm generating a bundle for a web app, as users won't have to download two copies of `lodash`.

