### PR TITLE
Make PROCESSING_INSTRUCTION regexp lazy

### DIFF
--- a/packages/parser/lib/lexer.js
+++ b/packages/parser/lib/lexer.js
@@ -103,7 +103,7 @@ const INVALID_SLASH_OPEN = createToken({
 
 const PROCESSING_INSTRUCTION = createToken({
   name: "PROCESSING_INSTRUCTION",
-  pattern: makePattern`<\\?${f.Name}.*\\?>`,
+  pattern: makePattern`<\\?${f.Name}.*?\\?>`,
 });
 
 const OPEN = createToken({ name: "OPEN", pattern: /</, push_mode: "INSIDE" });


### PR DESCRIPTION
Otherwise this fails with input like

```xml
<list><value id="all"><label>All</label></value><value id="one-one"><?group one?><label>One</label></value><value id="one-two"><?group one?><label>Two</label></value><value id="two-one"><?group two?><label>One</label></value><value id="two-two"><?group two?><label>Two</label></value></list>
```

where it will go to the end of the line to find the ?>