### PR TITLE
fix: support multiline processing instructions

### DIFF
--- a/packages/parser/lib/lexer.js
+++ b/packages/parser/lib/lexer.js
@@ -103,7 +103,7 @@ const INVALID_SLASH_OPEN = createToken({
 
 const PROCESSING_INSTRUCTION = createToken({
   name: "PROCESSING_INSTRUCTION",
-  pattern: makePattern`<\\?${f.Name}.*\\?>`,
+  pattern: makePattern`<\\?${f.Name}.*?\\?>`,
 });
 
 const OPEN = createToken({ name: "OPEN", pattern: /</, push_mode: "INSIDE" });

--- a/packages/parser/lib/lexer.js
+++ b/packages/parser/lib/lexer.js
@@ -103,7 +103,8 @@ const INVALID_SLASH_OPEN = createToken({
 
 const PROCESSING_INSTRUCTION = createToken({
   name: "PROCESSING_INSTRUCTION",
-  pattern: makePattern`<\\?${f.Name}.*?\\?>`,
+  pattern: makePattern`<\\?${f.Name}(?:.|\\r?\\n)*?\\?>`,
+  line_breaks: true,
 });
 
 const OPEN = createToken({ name: "OPEN", pattern: /</, push_mode: "INSIDE" });

--- a/packages/parser/test/parser-smoke-spec.js
+++ b/packages/parser/test/parser-smoke-spec.js
@@ -151,4 +151,31 @@ describe("The XML Parser", () => {
       "<?group two?>",
     ]);
   });
+
+  it("should tokenize multiline processing instructions with LF and CRLF", () => {
+    [
+      { lineEnding: "\n", expected: "<?group\n    one?>" },
+      { lineEnding: "\r\n", expected: "<?group\r\n    one?>" },
+    ].forEach(({ lineEnding, expected }) => {
+      const inputText = `<list>
+  <value id="moon-alpha">
+    <?group
+    one?>
+    <label>Moon Boots</label>
+  </value>
+</list>`.replace(/\n/g, lineEnding);
+      const { lexErrors, parseErrors, tokenVector } = parse(inputText);
+      const processingInstructionImages = tokenVector.reduce(
+        (images, token) =>
+          token.tokenType.name === "PROCESSING_INSTRUCTION"
+            ? [...images, token.image]
+            : images,
+        []
+      );
+
+      expect(lexErrors).to.be.empty;
+      expect(parseErrors).to.be.empty;
+      expect(processingInstructionImages).to.deep.equal([expected]);
+    });
+  });
 });

--- a/packages/parser/test/parser-smoke-spec.js
+++ b/packages/parser/test/parser-smoke-spec.js
@@ -129,4 +129,26 @@ describe("The XML Parser", () => {
     const lexAndParseResult = parse(inputText);
     expect(lexAndParseResult.parseErrors).to.be.empty;
   });
+
+  it("should tokenize processing instructions in sibling elements separately", () => {
+    const inputText =
+      '<list><value id="all"><label>All</label></value><value id="one-one"><?group one?><label>One</label></value><value id="one-two"><?group one?><label>Two</label></value><value id="two-one"><?group two?><label>One</label></value><value id="two-two"><?group two?><label>Two</label></value></list>';
+    const { lexErrors, parseErrors, tokenVector } = parse(inputText);
+    const processingInstructionImages = tokenVector.reduce(
+      (images, token) =>
+        token.tokenType.name === "PROCESSING_INSTRUCTION"
+          ? [...images, token.image]
+          : images,
+      []
+    );
+
+    expect(lexErrors).to.be.empty;
+    expect(parseErrors).to.be.empty;
+    expect(processingInstructionImages).to.deep.equal([
+      "<?group one?>",
+      "<?group one?>",
+      "<?group two?>",
+      "<?group two?>",
+    ]);
+  });
 });


### PR DESCRIPTION
This pull request depends on https://github.com/SAP/xml-tools/pull/464 and should be merged after it.

It builds on the `n/a-greedy` branch and extends the `PROCESSING_INSTRUCTION` lexer token to support multiline processing instructions.