### PR TITLE
fix(ast): update lodash to 4.18.1 to patch CVE-2026-2950 and CVE-2026-4800

### DIFF
--- a/packages/ast/package.json
+++ b/packages/ast/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@xml-tools/common": "^0.2.0",
     "@xml-tools/parser": "^1.0.11",
-    "lodash": "4.17.23"
+    "lodash": "^4.18.1"
   },
   "devDependencies": {
     "klaw-sync": "6.0.0"


### PR DESCRIPTION
## Summary

The `@xml-tools/ast` package pins `lodash` at `4.17.23`, which is affected by two security vulnerabilities patched in `4.18.0`:

| CVE | Severity | Description |
|-----|----------|-------------|
| **CVE-2026-2950** | High | Prototype pollution bypass in `_.unset`/`_.omit` — the fix for CVE-2025-13465 only guarded string key members; an attacker can bypass it via array-wrapped path segments, allowing deletion of properties from built-in prototypes (`Object.prototype`, etc.) |
| **CVE-2026-4800** | Critical (CVSS 9.8) | Code injection in `_.template` — arbitrary code execution when untrusted input is passed as `options.imports` key names |

Downstream consumers are currently forced to use `overrides`/`resolutions` in their own `package.json` to work around these advisories. Fixing it here removes that burden.

## Change

```diff
-    "lodash": "4.17.23"
+    "lodash": "^4.18.1"
```

Changed from an exact pin to a caret range so future patch releases are picked up automatically.

## Test plan

- [x] `npm test` in `packages/ast` — all **26 tests pass** before and after the change
- [x] Installed lodash version confirmed as `4.18.1`
- [x] `npm audit` no longer reports lodash vulnerabilities after the update